### PR TITLE
docs: rename agents.md to AGENTS.md and update heading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# Middleware
-
-Router supports a middleware chain around the Route pipeline.
+ # Middleware
+ 
+ Router supports a middleware chain around the Route pipeline.
 
 API:
 - type HandlerFunc func(ctx context.Context, state *RouteState) (RoutedResult, error)
@@ -12,7 +12,7 @@ Behavior:
 - Middlewares can read RouteState and modify the returned RoutedResult.
 - Middlewares execute even if no handler is registered.
 - Final ShouldDelete/Error is decided by Policy (default ImmediateDeletePolicy); middleware errors do not force delete by default.
-# agents.md — sqsrouter guide
+# AGENTS.md — sqsrouter guide
 
 This document is a practical guide to help you understand and use the sqsrouter codebase quickly. It consolidates architecture, usage, and operational tips so an AI agent or automation can reliably process SQS messages. Let’s go♪
 


### PR DESCRIPTION
Renames agents.md to AGENTS.md and updates the internal heading to match the filename.

Why
- Align with conventional uppercased top-level docs (e.g., README, LICENSE)
- Avoid case-sensitivity confusion across filesystems
- Improve discoverability and consistency

Changes
- Rename `agents.md` → `AGENTS.md`
- Update first-level heading to `# AGENTS.md — sqsrouter guide`

Notes
- No code changes; docs only
- Searched repo for `agents.md`; no references found