### PR TITLE
test(e2e): remove hardcoded sudo from docker compose calls

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -24,7 +24,7 @@ cleanup() {
   if [ ! -z "$APP_PID" ]; then
     kill "$APP_PID" 2>/dev/null || true
   fi
-  sudo docker compose -f "$DOCKER_COMPOSE_FILE" down -v
+  docker compose -f "$DOCKER_COMPOSE_FILE" down -v
   rm -f "$APP_LOG_FILE"
 }
 trap cleanup EXIT
@@ -87,7 +87,7 @@ echo "--- Starting e2e test ---"
 
 # 1) Start LocalStack
 echo "--- Starting LocalStack container ---"
-sudo docker compose -f "$DOCKER_COMPOSE_FILE" up -d
+docker compose -f "$DOCKER_COMPOSE_FILE" up -d
 
 echo "--- Waiting for SQS service to be available ---"
 SQS_WAIT_TIMEOUT="${SQS_WAIT_TIMEOUT:-60}"
@@ -107,7 +107,7 @@ if [ "$SQS_READY" -ne 1 ]; then
   echo
   echo "❌ Timeout waiting for SQS to become ready after ${SQS_WAIT_TIMEOUT}s."
   echo "--- docker logs (last 100 lines) ---"
-  sudo docker compose -f "$DOCKER_COMPOSE_FILE" logs --tail 100 || true
+  docker compose -f "$DOCKER_COMPOSE_FILE" logs --tail 100 || true
   exit 1
 fi
 echo " SQS is ready."


### PR DESCRIPTION
**Summary**

- Remove hardcoded `sudo` from `docker compose` calls in `test/e2e.sh` to improve portability and CI compatibility.

**Rationale**

- Most environments run Docker without `sudo` (Docker Desktop on macOS/Windows, Linux users in the `docker` group).
- Hardcoding `sudo` breaks CI/rootless setups and is unnecessary in typical dev environments.

**Changes**

- `test/e2e.sh` now calls `docker compose` directly for:
  - `up -d`
  - `down -v`
  - `logs --tail 100`

**Impact**

- Works out of the box when the current user can access Docker.
- On hosts that require elevation, run the script with `sudo` manually or add the user to the `docker` group.
- No functional changes to the test scenarios themselves.

**How to Run**

- `make e2e-test` or `./test/e2e.sh`

**Notes**

- No fallback/auto-detection logic added by design.
