### PR TITLE
router: unify policy application and panic handling in Route

### DIFF
--- a/policy_test.go
+++ b/policy_test.go
@@ -20,12 +20,12 @@ func TestImmediateDeletePolicy_Decide(t *testing.T) {
 	}
 
 	cases := []struct {
-		name        string
-		kind        FailureKind
-		innerErr    error
-		current     RoutedResult
-		wantDelete  bool
-		wantHasErr  bool
+		name       string
+		kind       FailureKind
+		innerErr   error
+		current    RoutedResult
+		wantDelete bool
+		wantHasErr bool
 	}{
 		{"FailNone_passthrough", FailNone, nil, base, false, false},
 		{"FailEnvelopeSchema_delete", FailEnvelopeSchema, errors.New("schema"), base, true, true},


### PR DESCRIPTION
This PR aligns failure handling and middleware behavior with the documented policies.\n\nChanges\n- Remove inner handler panic recovery from coreRoute; outer Route guard maps panics to FailHandlerPanic via Policy.\n- Apply Policy immediately for core structural failures and return a sentinel error (coreFailureErr) so middlewares can observe failures without re-applying policy.\n- Prevent duplicate Decide calls by detecting coreFailureErr in Route and returning the already-decided RoutedResult.\n- Update comments and formatting; keep middleware error path unchanged.\n\nWhy\n- Ensures FailHandlerPanic consistently flows through Policy (ImmediateDeletePolicy deletes; SQSRedrivePolicy retries).\n- Preserves middleware semantics (AFTER_ERR logs) while avoiding double policy evaluation.\n- Makes behavior match README/AGENTS guidance.\n\nValidation\n- Lint: passed via make lint (golangci-lint).\n- Unit tests: passed via go test ./... .\n- E2E: passed via make e2e-test (LocalStack).\n\nBackward compatibility\n- No public API changes; behavior becomes more consistent with documented policy.\n\nCreated by Codex