### PR TITLE
Route handler errors through Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ router, _ := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema, sqsrouter.WithPolicy(
 
 ### Failure Policy
 
-By default, the router uses ImmediateDeletePolicy which immediately deletes messages for structural/permanent failures (invalid envelope/payload, no handler, panics). This conserves resources but bypasses SQS DLQ redrive for such cases.
+By default, the router uses ImmediateDeletePolicy which immediately deletes messages for structural/permanent failures (invalid envelope/payload, no handler, panics). For handler and middleware errors, it attaches the error and respects the handler's `ShouldDelete` decision.
 
 If you prefer delegating all failures to SQS redrive so every failed message is retried per queue settings and eventually goes to the DLQ, use SQSRedrivePolicy:
 
@@ -132,6 +132,8 @@ router, _ := sqsrouter.NewRouter(
 
 - ImmediateDeletePolicy: fail-fast deletes on permanent/structural errors.
 - SQSRedrivePolicy: never deletes on failures; SQS manages retries and DLQ routing.
+
+All failures (including handler errors) are routed through the Policy, so you can centralize delete vs. retry decisions. The default behavior preserves handler intent; custom policies can override it.
 
 Middlewares run even if no handler is registered, so you can log/measure such cases.
 

--- a/policy.go
+++ b/policy.go
@@ -7,23 +7,23 @@ import (
 type FailureKind int
 
 const (
-    // FailNone indicates no failure occurred.
-    FailNone FailureKind = iota
+	// FailNone indicates no failure occurred.
+	FailNone FailureKind = iota
 	// FailEnvelopeSchema indicates the outer envelope JSON failed schema validation. (important-comment)
 	FailEnvelopeSchema
 	// FailEnvelopeParse indicates the outer envelope JSON could not be parsed at all.
 	FailEnvelopeParse
 	// FailPayloadSchema indicates the inner message payload failed its registered schema validation.
 	FailPayloadSchema
-    // FailNoHandler indicates no handler was registered for the message type/version.
-    FailNoHandler
-    // FailHandlerError indicates the user handler returned a non-nil error.
-    // Policy may choose to respect or override the handler's ShouldDelete decision.
-    FailHandlerError
-    // FailHandlerPanic indicates a panic occurred inside user handler or outer recovery.
-    FailHandlerPanic
-    // FailMiddlewareError indicates an error was returned by the middleware-wrapped core pipeline.
-    FailMiddlewareError
+	// FailNoHandler indicates no handler was registered for the message type/version.
+	FailNoHandler
+	// FailHandlerError indicates the user handler returned a non-nil error.
+	// Policy may choose to respect or override the handler's ShouldDelete decision.
+	FailHandlerError
+	// FailHandlerPanic indicates a panic occurred inside user handler or outer recovery.
+	FailHandlerPanic
+	// FailMiddlewareError indicates an error was returned by the middleware-wrapped core pipeline.
+	FailMiddlewareError
 )
 
 type Policy interface {
@@ -53,23 +53,23 @@ type ImmediateDeletePolicy struct{}
 // - For structural/permanent failures, mark ShouldDelete=true and attach inner error if not already present.
 // - For middleware errors, preserve ShouldDelete as-is (typically false) and attach inner error if missing.
 func (p ImmediateDeletePolicy) Decide(_ context.Context, _ *RouteState, kind FailureKind, inner error, rr RoutedResult) RoutedResult {
-    switch kind {
-    case FailNone:
-        return rr
-    case FailEnvelopeSchema, FailEnvelopeParse, FailPayloadSchema, FailNoHandler, FailHandlerPanic:
-        rr.HandlerResult.ShouldDelete = true
-        if inner != nil && rr.HandlerResult.Error == nil {
-            rr.HandlerResult.Error = inner
-        }
-        return rr
-    case FailMiddlewareError, FailHandlerError:
-        if inner != nil && rr.HandlerResult.Error == nil {
-            rr.HandlerResult.Error = inner
-        }
-        return rr
-    default:
-        return rr
-    }
+	switch kind {
+	case FailNone:
+		return rr
+	case FailEnvelopeSchema, FailEnvelopeParse, FailPayloadSchema, FailNoHandler, FailHandlerPanic:
+		rr.HandlerResult.ShouldDelete = true
+		if inner != nil && rr.HandlerResult.Error == nil {
+			rr.HandlerResult.Error = inner
+		}
+		return rr
+	case FailMiddlewareError, FailHandlerError:
+		if inner != nil && rr.HandlerResult.Error == nil {
+			rr.HandlerResult.Error = inner
+		}
+		return rr
+	default:
+		return rr
+	}
 }
 
 // SQSRedrivePolicy delegates failure handling to SQS redrive.

--- a/policy.go
+++ b/policy.go
@@ -7,20 +7,23 @@ import (
 type FailureKind int
 
 const (
-	// FailNone indicates no failure occurred.
-	FailNone FailureKind = iota
+    // FailNone indicates no failure occurred.
+    FailNone FailureKind = iota
 	// FailEnvelopeSchema indicates the outer envelope JSON failed schema validation. (important-comment)
 	FailEnvelopeSchema
 	// FailEnvelopeParse indicates the outer envelope JSON could not be parsed at all.
 	FailEnvelopeParse
 	// FailPayloadSchema indicates the inner message payload failed its registered schema validation.
 	FailPayloadSchema
-	// FailNoHandler indicates no handler was registered for the message type/version.
-	FailNoHandler
-	// FailHandlerPanic indicates a panic occurred inside user handler or outer recovery.
-	FailHandlerPanic
-	// FailMiddlewareError indicates an error was returned by the middleware-wrapped core pipeline.
-	FailMiddlewareError
+    // FailNoHandler indicates no handler was registered for the message type/version.
+    FailNoHandler
+    // FailHandlerError indicates the user handler returned a non-nil error.
+    // Policy may choose to respect or override the handler's ShouldDelete decision.
+    FailHandlerError
+    // FailHandlerPanic indicates a panic occurred inside user handler or outer recovery.
+    FailHandlerPanic
+    // FailMiddlewareError indicates an error was returned by the middleware-wrapped core pipeline.
+    FailMiddlewareError
 )
 
 type Policy interface {
@@ -50,23 +53,23 @@ type ImmediateDeletePolicy struct{}
 // - For structural/permanent failures, mark ShouldDelete=true and attach inner error if not already present.
 // - For middleware errors, preserve ShouldDelete as-is (typically false) and attach inner error if missing.
 func (p ImmediateDeletePolicy) Decide(_ context.Context, _ *RouteState, kind FailureKind, inner error, rr RoutedResult) RoutedResult {
-	switch kind {
-	case FailNone:
-		return rr
-	case FailEnvelopeSchema, FailEnvelopeParse, FailPayloadSchema, FailNoHandler, FailHandlerPanic:
-		rr.HandlerResult.ShouldDelete = true
-		if inner != nil && rr.HandlerResult.Error == nil {
-			rr.HandlerResult.Error = inner
-		}
-		return rr
-	case FailMiddlewareError:
-		if inner != nil && rr.HandlerResult.Error == nil {
-			rr.HandlerResult.Error = inner
-		}
-		return rr
-	default:
-		return rr
-	}
+    switch kind {
+    case FailNone:
+        return rr
+    case FailEnvelopeSchema, FailEnvelopeParse, FailPayloadSchema, FailNoHandler, FailHandlerPanic:
+        rr.HandlerResult.ShouldDelete = true
+        if inner != nil && rr.HandlerResult.Error == nil {
+            rr.HandlerResult.Error = inner
+        }
+        return rr
+    case FailMiddlewareError, FailHandlerError:
+        if inner != nil && rr.HandlerResult.Error == nil {
+            rr.HandlerResult.Error = inner
+        }
+        return rr
+    default:
+        return rr
+    }
 }
 
 // SQSRedrivePolicy delegates failure handling to SQS redrive.

--- a/policy_test.go
+++ b/policy_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestImmediateDeletePolicy_Decide(t *testing.T) {
-    p := ImmediateDeletePolicy{}
+	p := ImmediateDeletePolicy{}
 	ctx := context.Background()
 	st := &RouteState{}
 
@@ -19,30 +19,30 @@ func TestImmediateDeletePolicy_Decide(t *testing.T) {
 		Timestamp:      "ts",
 	}
 
-    cases := []struct {
-        name       string
-        kind       FailureKind
-        innerErr   error
-        current    RoutedResult
-        wantDelete bool
-        wantHasErr bool
-    }{
-        {"FailNone_passthrough", FailNone, nil, base, false, false},
-        {"FailEnvelopeSchema_delete", FailEnvelopeSchema, errors.New("schema"), base, true, true},
-        {"FailEnvelopeParse_delete", FailEnvelopeParse, errors.New("parse"), base, true, true},
-        {"FailPayloadSchema_delete", FailPayloadSchema, errors.New("payload"), base, true, true},
-        {"FailNoHandler_delete", FailNoHandler, errors.New("nohandler"), base, true, true},
-        {"FailHandlerError_respect_handler", FailHandlerError, errors.New("handler"), base, false, true},
-        {"FailHandlerPanic_delete", FailHandlerPanic, errors.New("panic"), base, true, true},
-        {"FailMiddlewareError_retry_attach_err", FailMiddlewareError, errors.New("mw"), base, false, true},
-        {"FailMiddlewareError_retry_preserve_existing_err", FailMiddlewareError, errors.New("ignored"), RoutedResult{
-            MessageType:    "t",
-            MessageVersion: "v",
-            HandlerResult:  HandlerResult{ShouldDelete: false, Error: errors.New("already")},
-            MessageID:      "id",
-            Timestamp:      "ts",
-        }, false, true},
-    }
+	cases := []struct {
+		name       string
+		kind       FailureKind
+		innerErr   error
+		current    RoutedResult
+		wantDelete bool
+		wantHasErr bool
+	}{
+		{"FailNone_passthrough", FailNone, nil, base, false, false},
+		{"FailEnvelopeSchema_delete", FailEnvelopeSchema, errors.New("schema"), base, true, true},
+		{"FailEnvelopeParse_delete", FailEnvelopeParse, errors.New("parse"), base, true, true},
+		{"FailPayloadSchema_delete", FailPayloadSchema, errors.New("payload"), base, true, true},
+		{"FailNoHandler_delete", FailNoHandler, errors.New("nohandler"), base, true, true},
+		{"FailHandlerError_respect_handler", FailHandlerError, errors.New("handler"), base, false, true},
+		{"FailHandlerPanic_delete", FailHandlerPanic, errors.New("panic"), base, true, true},
+		{"FailMiddlewareError_retry_attach_err", FailMiddlewareError, errors.New("mw"), base, false, true},
+		{"FailMiddlewareError_retry_preserve_existing_err", FailMiddlewareError, errors.New("ignored"), RoutedResult{
+			MessageType:    "t",
+			MessageVersion: "v",
+			HandlerResult:  HandlerResult{ShouldDelete: false, Error: errors.New("already")},
+			MessageID:      "id",
+			Timestamp:      "ts",
+		}, false, true},
+	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -104,19 +104,19 @@ func TestWithPolicy_SetsRouterPolicy(t *testing.T) {
 	}
 }
 func TestSQSRedrivePolicy_AllFailuresShouldNotDelete(t *testing.T) {
-    p := SQSRedrivePolicy{}
+	p := SQSRedrivePolicy{}
 	ctx := context.Background()
 	st := &RouteState{}
 
-    kinds := []FailureKind{
-        FailEnvelopeSchema,
-        FailEnvelopeParse,
-        FailPayloadSchema,
-        FailNoHandler,
-        FailHandlerError,
-        FailHandlerPanic,
-        FailMiddlewareError,
-    }
+	kinds := []FailureKind{
+		FailEnvelopeSchema,
+		FailEnvelopeParse,
+		FailPayloadSchema,
+		FailNoHandler,
+		FailHandlerError,
+		FailHandlerPanic,
+		FailMiddlewareError,
+	}
 
 	for _, k := range kinds {
 		inner := errors.New("inner")

--- a/policy_test.go
+++ b/policy_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestImmediateDeletePolicy_Decide(t *testing.T) {
-	p := ImmediateDeletePolicy{}
+    p := ImmediateDeletePolicy{}
 	ctx := context.Background()
 	st := &RouteState{}
 
@@ -19,29 +19,30 @@ func TestImmediateDeletePolicy_Decide(t *testing.T) {
 		Timestamp:      "ts",
 	}
 
-	cases := []struct {
-		name       string
-		kind       FailureKind
-		innerErr   error
-		current    RoutedResult
-		wantDelete bool
-		wantHasErr bool
-	}{
-		{"FailNone_passthrough", FailNone, nil, base, false, false},
-		{"FailEnvelopeSchema_delete", FailEnvelopeSchema, errors.New("schema"), base, true, true},
-		{"FailEnvelopeParse_delete", FailEnvelopeParse, errors.New("parse"), base, true, true},
-		{"FailPayloadSchema_delete", FailPayloadSchema, errors.New("payload"), base, true, true},
-		{"FailNoHandler_delete", FailNoHandler, errors.New("nohandler"), base, true, true},
-		{"FailHandlerPanic_delete", FailHandlerPanic, errors.New("panic"), base, true, true},
-		{"FailMiddlewareError_retry_attach_err", FailMiddlewareError, errors.New("mw"), base, false, true},
-		{"FailMiddlewareError_retry_preserve_existing_err", FailMiddlewareError, errors.New("ignored"), RoutedResult{
-			MessageType:    "t",
-			MessageVersion: "v",
-			HandlerResult:  HandlerResult{ShouldDelete: false, Error: errors.New("already")},
-			MessageID:      "id",
-			Timestamp:      "ts",
-		}, false, true},
-	}
+    cases := []struct {
+        name       string
+        kind       FailureKind
+        innerErr   error
+        current    RoutedResult
+        wantDelete bool
+        wantHasErr bool
+    }{
+        {"FailNone_passthrough", FailNone, nil, base, false, false},
+        {"FailEnvelopeSchema_delete", FailEnvelopeSchema, errors.New("schema"), base, true, true},
+        {"FailEnvelopeParse_delete", FailEnvelopeParse, errors.New("parse"), base, true, true},
+        {"FailPayloadSchema_delete", FailPayloadSchema, errors.New("payload"), base, true, true},
+        {"FailNoHandler_delete", FailNoHandler, errors.New("nohandler"), base, true, true},
+        {"FailHandlerError_respect_handler", FailHandlerError, errors.New("handler"), base, false, true},
+        {"FailHandlerPanic_delete", FailHandlerPanic, errors.New("panic"), base, true, true},
+        {"FailMiddlewareError_retry_attach_err", FailMiddlewareError, errors.New("mw"), base, false, true},
+        {"FailMiddlewareError_retry_preserve_existing_err", FailMiddlewareError, errors.New("ignored"), RoutedResult{
+            MessageType:    "t",
+            MessageVersion: "v",
+            HandlerResult:  HandlerResult{ShouldDelete: false, Error: errors.New("already")},
+            MessageID:      "id",
+            Timestamp:      "ts",
+        }, false, true},
+    }
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -103,18 +104,19 @@ func TestWithPolicy_SetsRouterPolicy(t *testing.T) {
 	}
 }
 func TestSQSRedrivePolicy_AllFailuresShouldNotDelete(t *testing.T) {
-	p := SQSRedrivePolicy{}
+    p := SQSRedrivePolicy{}
 	ctx := context.Background()
 	st := &RouteState{}
 
-	kinds := []FailureKind{
-		FailEnvelopeSchema,
-		FailEnvelopeParse,
-		FailPayloadSchema,
-		FailNoHandler,
-		FailHandlerPanic,
-		FailMiddlewareError,
-	}
+    kinds := []FailureKind{
+        FailEnvelopeSchema,
+        FailEnvelopeParse,
+        FailPayloadSchema,
+        FailNoHandler,
+        FailHandlerError,
+        FailHandlerPanic,
+        FailMiddlewareError,
+    }
 
 	for _, k := range kinds {
 		inner := errors.New("inner")

--- a/router.go
+++ b/router.go
@@ -200,21 +200,21 @@ func (r *Router) coreRoute(ctx context.Context, state *RouteState) (RoutedResult
 	// Do not recover here; allow panics to bubble to Route, which maps them to FailHandlerPanic via Policy.
 	handlerResult := handler(ctx, envelope.Message, metaJSON)
 
-    // Assemble the routed result from handler output.
-    rr := RoutedResult{
-        MessageType:    envelope.MessageType,
-        MessageVersion: envelope.MessageVersion,
-        HandlerResult:  handlerResult,
-        MessageID:      meta.MessageID,
-        Timestamp:      meta.Timestamp,
-    }
-    // If handler returned an error, consult Policy so it can be the final decider.
-    if handlerResult.Error != nil {
-        decided := r.policy.Decide(ctx, state, FailHandlerError, handlerResult.Error, rr)
-        return decided, nil
-    }
-    // No error: return as-is.
-    return rr, nil
+	// Assemble the routed result from handler output.
+	rr := RoutedResult{
+		MessageType:    envelope.MessageType,
+		MessageVersion: envelope.MessageVersion,
+		HandlerResult:  handlerResult,
+		MessageID:      meta.MessageID,
+		Timestamp:      meta.Timestamp,
+	}
+	// If handler returned an error, consult Policy so it can be the final decider.
+	if handlerResult.Error != nil {
+		decided := r.policy.Decide(ctx, state, FailHandlerError, handlerResult.Error, rr)
+		return decided, nil
+	}
+	// No error: return as-is.
+	return rr, nil
 }
 
 // Route validates and dispatches a raw message to the appropriate registered handler.

--- a/router_test.go
+++ b/router_test.go
@@ -135,49 +135,49 @@ func TestRouter_Route(t *testing.T) {
 		assert.Equal(t, "test-id-123", result.MessageID)
 	})
 
-    t.Run("should return error from handler", func(t *testing.T) {
-        r := newTestRouter(t)
-        r.Register(testMessageType, testMessageVersion, testErrorHandler)
+	t.Run("should return error from handler", func(t *testing.T) {
+		r := newTestRouter(t)
+		r.Register(testMessageType, testMessageVersion, testErrorHandler)
 
 		payload := `{"userId": "123", "username": "test"}`
 		msg := createTestMessage(t, testMessageType, testMessageVersion, payload)
 
 		result := r.Route(context.Background(), msg)
 
-        assert.Error(t, result.HandlerResult.Error)
-        assert.Equal(t, "handler failed", result.HandlerResult.Error.Error())
-        assert.True(t, result.HandlerResult.ShouldDelete)
-    })
+		assert.Error(t, result.HandlerResult.Error)
+		assert.Equal(t, "handler failed", result.HandlerResult.Error.Error())
+		assert.True(t, result.HandlerResult.ShouldDelete)
+	})
 
-    t.Run("policy can override handler error decision", func(t *testing.T) {
-        // Custom policy that forces retry on handler errors regardless of handler's ShouldDelete
-        tp := &testPolicy{
-            decideFunc: func(ctx context.Context, st *RouteState, kind FailureKind, inner error, current RoutedResult) RoutedResult {
-                if kind == FailHandlerError {
-                    current.HandlerResult.ShouldDelete = false
-                    if inner != nil && current.HandlerResult.Error == nil {
-                        current.HandlerResult.Error = inner
-                    }
-                    return current
-                }
-                return current
-            },
-        }
-        r, err := NewRouter(testEnvelopeSchema, WithPolicy(tp))
-        require.NoError(t, err)
-        // Handler asks to delete even on error
-        r.Register(testMessageType, testMessageVersion, func(_ context.Context, _, _ []byte) HandlerResult {
-            return HandlerResult{ShouldDelete: true, Error: errors.New("boom")}
-        })
+	t.Run("policy can override handler error decision", func(t *testing.T) {
+		// Custom policy that forces retry on handler errors regardless of handler's ShouldDelete
+		tp := &testPolicy{
+			decideFunc: func(ctx context.Context, st *RouteState, kind FailureKind, inner error, current RoutedResult) RoutedResult {
+				if kind == FailHandlerError {
+					current.HandlerResult.ShouldDelete = false
+					if inner != nil && current.HandlerResult.Error == nil {
+						current.HandlerResult.Error = inner
+					}
+					return current
+				}
+				return current
+			},
+		}
+		r, err := NewRouter(testEnvelopeSchema, WithPolicy(tp))
+		require.NoError(t, err)
+		// Handler asks to delete even on error
+		r.Register(testMessageType, testMessageVersion, func(_ context.Context, _, _ []byte) HandlerResult {
+			return HandlerResult{ShouldDelete: true, Error: errors.New("boom")}
+		})
 
-        payload := `{"userId": "123", "username": "test"}`
-        msg := createTestMessage(t, testMessageType, testMessageVersion, payload)
-        result := r.Route(context.Background(), msg)
+		payload := `{"userId": "123", "username": "test"}`
+		msg := createTestMessage(t, testMessageType, testMessageVersion, payload)
+		result := r.Route(context.Background(), msg)
 
-        assert.Error(t, result.HandlerResult.Error)
-        assert.Equal(t, "boom", result.HandlerResult.Error.Error())
-        assert.False(t, result.HandlerResult.ShouldDelete, "policy override should force retry")
-    })
+		assert.Error(t, result.HandlerResult.Error)
+		assert.Equal(t, "boom", result.HandlerResult.Error.Error())
+		assert.False(t, result.HandlerResult.ShouldDelete, "policy override should force retry")
+	})
 
 	t.Run("should handle retry logic from handler", func(t *testing.T) {
 		r := newTestRouter(t)

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -169,4 +169,18 @@ wait_for_log "E2E_MW_BEFORE"
 wait_for_log "E2E_MW_AFTER_ERR"
 wait_for_log "RETRYING message ID"
 
+echo "--- Scenario 5: Policy overrides handler error to retry ---"
+kill "$APP_PID" 2>/dev/null || true
+sleep 2
+export E2E_POLICY_FORCE_RETRY_ON_HANDLER_ERR=1
+export E2E_HANDLER_FORCE_ERR=1
+unset E2E_MW_FAIL
+unset E2E_MW_TOUCH
+start_app
+
+TEST_ID4=$(cat /proc/sys/kernel/random/uuid)
+send_message "e2eTest" "1.0" "{\"testId\": \"$TEST_ID4\", \"payload\": \"handler error scenario\"}"
+wait_for_log "E2E_TEST_SUCCESS: Received message for test ID $TEST_ID4"
+wait_for_log "RETRYING message ID"
+
 echo "✅ All E2E scenarios passed."

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -28,16 +28,19 @@ type E2ETestMessage struct {
 
 // E2ETestHandler handles the logic for the e2e test message.
 func E2ETestHandler(ctx context.Context, messageJSON []byte, metadataJSON []byte) sqsrouter.HandlerResult {
-	var msg E2ETestMessage
-	if err := json.Unmarshal(messageJSON, &msg); err != nil {
-		return sqsrouter.HandlerResult{ShouldDelete: true, Error: fmt.Errorf("failed to unmarshal e2e test message: %w", err)}
-	}
+    var msg E2ETestMessage
+    if err := json.Unmarshal(messageJSON, &msg); err != nil {
+        return sqsrouter.HandlerResult{ShouldDelete: true, Error: fmt.Errorf("failed to unmarshal e2e test message: %w", err)}
+    }
 
-	// For the e2e test, we just log the message content.
-	// The test script will check the log output for this message.
-	log.Printf("E2E_TEST_SUCCESS: Received message for test ID %s with payload: %s", msg.TestID, msg.Payload)
-
-	return sqsrouter.HandlerResult{ShouldDelete: true, Error: nil}
+    // For the e2e test, we just log the message content.
+    // The test script will check the log output for this message.
+    log.Printf("E2E_TEST_SUCCESS: Received message for test ID %s with payload: %s", msg.TestID, msg.Payload)
+    // If enabled, force an application-level error to exercise policy behavior.
+    if os.Getenv("E2E_HANDLER_FORCE_ERR") == "1" {
+        return sqsrouter.HandlerResult{ShouldDelete: true, Error: fmt.Errorf("e2e handler forced error")}
+    }
+    return sqsrouter.HandlerResult{ShouldDelete: true, Error: nil}
 }
 
 type e2eMiddleware struct{}
@@ -92,8 +95,24 @@ func (e e2eMiddleware) handler(next sqsrouter.HandlerFunc) sqsrouter.HandlerFunc
 }
 
 func E2EMiddleware() sqsrouter.Middleware {
-	mw := e2eMiddleware{}
-	return func(next sqsrouter.HandlerFunc) sqsrouter.HandlerFunc { return mw.handler(next) }
+    mw := e2eMiddleware{}
+    return func(next sqsrouter.HandlerFunc) sqsrouter.HandlerFunc { return mw.handler(next) }
+}
+
+// forceRetryOnHandlerErr is a custom Policy used in E2E to demonstrate that
+// handler errors are passed through Policy and can be centrally overridden.
+type forceRetryOnHandlerErr struct{}
+
+// Decide implements the Policy interface for the custom behavior.
+func (forceRetryOnHandlerErr) Decide(_ context.Context, _ *sqsrouter.RouteState, kind sqsrouter.FailureKind, inner error, rr sqsrouter.RoutedResult) sqsrouter.RoutedResult {
+    if kind == sqsrouter.FailHandlerError {
+        rr.HandlerResult.ShouldDelete = false
+        if inner != nil && rr.HandlerResult.Error == nil {
+            rr.HandlerResult.Error = inner
+        }
+        return rr
+    }
+    return rr
 }
 
 func main() {
@@ -132,7 +151,14 @@ func main() {
 
 	sqsClient := sqs.NewFromConfig(cfg)
 
-	router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
+    // Optionally install a custom policy that forces retry for handler errors.
+    var opts []sqsrouter.RouterOption
+    if os.Getenv("E2E_POLICY_FORCE_RETRY_ON_HANDLER_ERR") == "1" {
+        // Custom policy: turn any handler error into a retry (ShouldDelete=false)
+        opts = append(opts, sqsrouter.WithPolicy(forceRetryOnHandlerErr{}))
+    }
+
+    router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema, opts...)
 	if err != nil {
 		log.Fatalf("Could not initialize router: %v", err)
 	}

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -28,19 +28,19 @@ type E2ETestMessage struct {
 
 // E2ETestHandler handles the logic for the e2e test message.
 func E2ETestHandler(ctx context.Context, messageJSON []byte, metadataJSON []byte) sqsrouter.HandlerResult {
-    var msg E2ETestMessage
-    if err := json.Unmarshal(messageJSON, &msg); err != nil {
-        return sqsrouter.HandlerResult{ShouldDelete: true, Error: fmt.Errorf("failed to unmarshal e2e test message: %w", err)}
-    }
+	var msg E2ETestMessage
+	if err := json.Unmarshal(messageJSON, &msg); err != nil {
+		return sqsrouter.HandlerResult{ShouldDelete: true, Error: fmt.Errorf("failed to unmarshal e2e test message: %w", err)}
+	}
 
-    // For the e2e test, we just log the message content.
-    // The test script will check the log output for this message.
-    log.Printf("E2E_TEST_SUCCESS: Received message for test ID %s with payload: %s", msg.TestID, msg.Payload)
-    // If enabled, force an application-level error to exercise policy behavior.
-    if os.Getenv("E2E_HANDLER_FORCE_ERR") == "1" {
-        return sqsrouter.HandlerResult{ShouldDelete: true, Error: fmt.Errorf("e2e handler forced error")}
-    }
-    return sqsrouter.HandlerResult{ShouldDelete: true, Error: nil}
+	// For the e2e test, we just log the message content.
+	// The test script will check the log output for this message.
+	log.Printf("E2E_TEST_SUCCESS: Received message for test ID %s with payload: %s", msg.TestID, msg.Payload)
+	// If enabled, force an application-level error to exercise policy behavior.
+	if os.Getenv("E2E_HANDLER_FORCE_ERR") == "1" {
+		return sqsrouter.HandlerResult{ShouldDelete: true, Error: fmt.Errorf("e2e handler forced error")}
+	}
+	return sqsrouter.HandlerResult{ShouldDelete: true, Error: nil}
 }
 
 type e2eMiddleware struct{}
@@ -95,8 +95,8 @@ func (e e2eMiddleware) handler(next sqsrouter.HandlerFunc) sqsrouter.HandlerFunc
 }
 
 func E2EMiddleware() sqsrouter.Middleware {
-    mw := e2eMiddleware{}
-    return func(next sqsrouter.HandlerFunc) sqsrouter.HandlerFunc { return mw.handler(next) }
+	mw := e2eMiddleware{}
+	return func(next sqsrouter.HandlerFunc) sqsrouter.HandlerFunc { return mw.handler(next) }
 }
 
 // forceRetryOnHandlerErr is a custom Policy used in E2E to demonstrate that
@@ -105,14 +105,14 @@ type forceRetryOnHandlerErr struct{}
 
 // Decide implements the Policy interface for the custom behavior.
 func (forceRetryOnHandlerErr) Decide(_ context.Context, _ *sqsrouter.RouteState, kind sqsrouter.FailureKind, inner error, rr sqsrouter.RoutedResult) sqsrouter.RoutedResult {
-    if kind == sqsrouter.FailHandlerError {
-        rr.HandlerResult.ShouldDelete = false
-        if inner != nil && rr.HandlerResult.Error == nil {
-            rr.HandlerResult.Error = inner
-        }
-        return rr
-    }
-    return rr
+	if kind == sqsrouter.FailHandlerError {
+		rr.HandlerResult.ShouldDelete = false
+		if inner != nil && rr.HandlerResult.Error == nil {
+			rr.HandlerResult.Error = inner
+		}
+		return rr
+	}
+	return rr
 }
 
 func main() {
@@ -151,14 +151,14 @@ func main() {
 
 	sqsClient := sqs.NewFromConfig(cfg)
 
-    // Optionally install a custom policy that forces retry for handler errors.
-    var opts []sqsrouter.RouterOption
-    if os.Getenv("E2E_POLICY_FORCE_RETRY_ON_HANDLER_ERR") == "1" {
-        // Custom policy: turn any handler error into a retry (ShouldDelete=false)
-        opts = append(opts, sqsrouter.WithPolicy(forceRetryOnHandlerErr{}))
-    }
+	// Optionally install a custom policy that forces retry for handler errors.
+	var opts []sqsrouter.RouterOption
+	if os.Getenv("E2E_POLICY_FORCE_RETRY_ON_HANDLER_ERR") == "1" {
+		// Custom policy: turn any handler error into a retry (ShouldDelete=false)
+		opts = append(opts, sqsrouter.WithPolicy(forceRetryOnHandlerErr{}))
+	}
 
-    router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema, opts...)
+	router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema, opts...)
 	if err != nil {
 		log.Fatalf("Could not initialize router: %v", err)
 	}


### PR DESCRIPTION
## Summary
This change routes handler-returned errors through the Policy layer by introducing a new FailureKind (FailHandlerError) and consulting Policy after handler execution when an error is present. The default ImmediateDeletePolicy respects the handler’s ShouldDelete decision while attaching the error; custom policies can now centrally override delete vs. retry for handler errors.

## Changes
- Add FailureKind: FailHandlerError
- router: call Policy.Decide when handler returns an error
- unit tests: add coverage for FailHandlerError and policy override
- e2e: add scenario demonstrating policy overriding handler error to retry
- docs: README and AGENTS.md updated to describe uniform policy application, including handler errors

## Motivation
Unify failure handling so all failure paths (envelope/schema/no-handler/middleware/panic/handler errors) are decided by Policy. This reduces user confusion and allows centralized operational control.

## Compatibility
Default behavior remains effectively the same: ImmediateDeletePolicy respects the handler’s ShouldDelete. Users can opt into a custom Policy to change behavior.

Created by Codex