### PR TITLE
refactor(types): extract shared types and set default routing policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,9 @@ A concise, automation-friendly guide for AI agents and tooling to understand, na
 ```
 
 ## Key Types and APIs
-- types.go
+- types/
+  - types.MessageEnvelope, types.MessageMetadata, types.HandlerKey, types.RoutingPolicy
+- sqsrouter (root)
   - type MessageHandler func(ctx context.Context, messageJSON []byte, metadataJSON []byte) HandlerResult
   - type HandlerFunc func(ctx context.Context, state *RouteState) (RoutedResult, error)
   - type Middleware func(next HandlerFunc) HandlerFunc
@@ -115,7 +117,7 @@ go mod tidy
 
 ## Extending
 - New FailurePolicy: implement failure.FailurePolicy and pass with WithFailurePolicy(...) when creating Router.
-- New RoutingPolicy: implement sqsrouter.RoutingPolicy and pass with WithRoutingPolicy(...).
+- New RoutingPolicy: implement types.RoutingPolicy and pass with WithRoutingPolicy(...).
 - New Middleware: implement Middleware and register via router.Use(...).
 - New Handlers: router.Register("Type", "Version", handler) and (optionally) RegisterSchema.
 

--- a/README.md
+++ b/README.md
@@ -171,13 +171,14 @@ router, _ := sqsrouter.NewRouter(
 ```
 
 ```go
-// Define a custom routing policy by implementing sqsrouter.RoutingPolicy
+// Define a custom routing policy by implementing types.RoutingPolicy
+// import types "github.com/hatsunemiku3939/sqsrouter/types"
 type MyRoutingPolicy struct{}
-func (MyRoutingPolicy) Decide(ctx context.Context, env *sqsrouter.MessageEnvelope, available []sqsrouter.HandlerKey) sqsrouter.HandlerKey {
+func (MyRoutingPolicy) Decide(ctx context.Context, env *types.MessageEnvelope, available []types.HandlerKey) types.HandlerKey {
   // Example: fallback to v1 if exact match not found
-  want := sqsrouter.HandlerKey(env.MessageType + ":" + env.MessageVersion)
+  want := types.HandlerKey(env.MessageType + ":" + env.MessageVersion)
   for _, k := range available { if k == want { return k } }
-  fallback := sqsrouter.HandlerKey(env.MessageType + ":v1")
+  fallback := types.HandlerKey(env.MessageType + ":v1")
   for _, k := range available { if k == fallback { return k } }
   return ""
 }
@@ -197,7 +198,7 @@ sqsrouter/
 │   └── routing/                # Routing policy (ExactMatchPolicy, custom implementations)
 ├── internal/jsonschema/        # JSON schema validation utilities
 ├── router.go                   # Routing by type/version, schema validation, handler registry
-├── types.go                    # Public types and interfaces
+├── types/                      # Shared public types (envelope, keys, interfaces)
 ├── example/
 │   └── basic/                  # Minimal runnable example
 ├── test/

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -1,19 +1,19 @@
 package consumer
 
 import (
-    "context"
-    "errors"
-    "fmt"
-    "testing"
-    "time"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
 
-    "github.com/aws/aws-sdk-go-v2/service/sqs"
-    "github.com/aws/aws-sdk-go-v2/service/sqs/types"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/mock"
-    "github.com/stretchr/testify/require"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
-    sqsrouter "github.com/hatsunemiku3939/sqsrouter"
+	sqsrouter "github.com/hatsunemiku3939/sqsrouter"
 )
 
 // --- Mock SQSClient ---
@@ -21,186 +21,185 @@ import (
 type MockSQSClient struct{ mock.Mock }
 
 func (m *MockSQSClient) ReceiveMessage(ctx context.Context, params *sqs.ReceiveMessageInput, optFns ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error) {
-    args := m.Called(ctx, params)
-    if args.Get(0) == nil {
-        return nil, args.Error(1)
-    }
-    return args.Get(0).(*sqs.ReceiveMessageOutput), args.Error(1)
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sqs.ReceiveMessageOutput), args.Error(1)
 }
 
 func (m *MockSQSClient) DeleteMessage(ctx context.Context, params *sqs.DeleteMessageInput, optFns ...func(*sqs.Options)) (*sqs.DeleteMessageOutput, error) {
-    args := m.Called(ctx, params)
-    if args.Get(0) == nil {
-        return nil, args.Error(1)
-    }
-    return args.Get(0).(*sqs.DeleteMessageOutput), args.Error(1)
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*sqs.DeleteMessageOutput), args.Error(1)
 }
 
 func createSQSMessage(body, receiptHandle string) types.Message {
-    return types.Message{Body: &body, ReceiptHandle: &receiptHandle}
+	return types.Message{Body: &body, ReceiptHandle: &receiptHandle}
 }
 
 func TestNewConsumer(t *testing.T) {
-    mockClient := new(MockSQSClient)
-    router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
-    require.NoError(t, err)
-    c := NewConsumer(mockClient, "test-queue-url", router)
+	mockClient := new(MockSQSClient)
+	router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
+	require.NoError(t, err)
+	c := NewConsumer(mockClient, "test-queue-url", router)
 
-    assert.NotNil(t, c)
-    assert.Equal(t, "test-queue-url", c.queueURL)
-    assert.Equal(t, mockClient, c.client)
-    assert.Equal(t, router, c.router)
+	assert.NotNil(t, c)
+	assert.Equal(t, "test-queue-url", c.queueURL)
+	assert.Equal(t, mockClient, c.client)
+	assert.Equal(t, router, c.router)
 }
 
 func TestConsumer_processMessage(t *testing.T) {
-    queueURL := "test-queue"
+	queueURL := "test-queue"
 
-    tests := []struct {
-        name                 string
-        handler              sqsrouter.MessageHandler
-        shouldDelete         bool
-        expectDeleteCall     bool
-        deleteShouldFail     bool
-        expectedDeleteErrMsg string
-    }{
-        {
-            name: "success, should delete",
-            handler: func(ctx context.Context, msg []byte, meta []byte) sqsrouter.HandlerResult {
-                return sqsrouter.HandlerResult{ShouldDelete: true, Error: nil}
-            },
-            shouldDelete:     true,
-            expectDeleteCall: true,
-        },
-        {
-            name: "handler error, but should delete",
-            handler: func(ctx context.Context, msg []byte, meta []byte) sqsrouter.HandlerResult {
-                return sqsrouter.HandlerResult{ShouldDelete: true, Error: errors.New("permanent failure")}
-            },
-            shouldDelete:     true,
-            expectDeleteCall: true,
-        },
-        {
-            name: "handler error, should not delete (retry)",
-            handler: func(ctx context.Context, msg []byte, meta []byte) sqsrouter.HandlerResult {
-                return sqsrouter.HandlerResult{ShouldDelete: false, Error: errors.New("transient error")}
-            },
-            shouldDelete:     false,
-            expectDeleteCall: false,
-        },
-        {
-            name: "success, but delete fails",
-            handler: func(ctx context.Context, msg []byte, meta []byte) sqsrouter.HandlerResult {
-                return sqsrouter.HandlerResult{ShouldDelete: true, Error: nil}
-            },
-            shouldDelete:         true,
-            expectDeleteCall:     true,
-            deleteShouldFail:     true,
-            expectedDeleteErrMsg: "failed to delete",
-        },
-    }
+	tests := []struct {
+		name                 string
+		handler              sqsrouter.MessageHandler
+		shouldDelete         bool
+		expectDeleteCall     bool
+		deleteShouldFail     bool
+		expectedDeleteErrMsg string
+	}{
+		{
+			name: "success, should delete",
+			handler: func(ctx context.Context, msg []byte, meta []byte) sqsrouter.HandlerResult {
+				return sqsrouter.HandlerResult{ShouldDelete: true, Error: nil}
+			},
+			shouldDelete:     true,
+			expectDeleteCall: true,
+		},
+		{
+			name: "handler error, but should delete",
+			handler: func(ctx context.Context, msg []byte, meta []byte) sqsrouter.HandlerResult {
+				return sqsrouter.HandlerResult{ShouldDelete: true, Error: errors.New("permanent failure")}
+			},
+			shouldDelete:     true,
+			expectDeleteCall: true,
+		},
+		{
+			name: "handler error, should not delete (retry)",
+			handler: func(ctx context.Context, msg []byte, meta []byte) sqsrouter.HandlerResult {
+				return sqsrouter.HandlerResult{ShouldDelete: false, Error: errors.New("transient error")}
+			},
+			shouldDelete:     false,
+			expectDeleteCall: false,
+		},
+		{
+			name: "success, but delete fails",
+			handler: func(ctx context.Context, msg []byte, meta []byte) sqsrouter.HandlerResult {
+				return sqsrouter.HandlerResult{ShouldDelete: true, Error: nil}
+			},
+			shouldDelete:         true,
+			expectDeleteCall:     true,
+			deleteShouldFail:     true,
+			expectedDeleteErrMsg: "failed to delete",
+		},
+	}
 
-    for _, tt := range tests {
-        t.Run(tt.name, func(t *testing.T) {
-            mockClient := new(MockSQSClient)
-            router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
-            require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := new(MockSQSClient)
+			router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
+			require.NoError(t, err)
 
-            msgType, msgVersion := "test.event", "1.0"
-            router.Register(msgType, msgVersion, tt.handler)
+			msgType, msgVersion := "test.event", "1.0"
+			router.Register(msgType, msgVersion, tt.handler)
 
-            c := NewConsumer(mockClient, queueURL, router)
+			c := NewConsumer(mockClient, queueURL, router)
 
-            msgBody := fmt.Sprintf(`{
+			msgBody := fmt.Sprintf(`{
                 "schemaVersion": "1.0", "messageType": "%s", "messageVersion": "%s",
                 "message": {}, "metadata": {"messageId": "msg-1"}
             }`, msgType, msgVersion)
-            sqsMsg := createSQSMessage(msgBody, "receipt-1")
+			sqsMsg := createSQSMessage(msgBody, "receipt-1")
 
-            if tt.expectDeleteCall {
-                deleteCall := mockClient.On("DeleteMessage", mock.Anything, mock.Anything)
-                if tt.deleteShouldFail {
-                    deleteCall.Return(nil, errors.New(tt.expectedDeleteErrMsg))
-                } else {
-                    deleteCall.Return(&sqs.DeleteMessageOutput{}, nil)
-                }
-            }
+			if tt.expectDeleteCall {
+				deleteCall := mockClient.On("DeleteMessage", mock.Anything, mock.Anything)
+				if tt.deleteShouldFail {
+					deleteCall.Return(nil, errors.New(tt.expectedDeleteErrMsg))
+				} else {
+					deleteCall.Return(&sqs.DeleteMessageOutput{}, nil)
+				}
+			}
 
-            c.processMessage(context.Background(), &sqsMsg)
+			c.processMessage(context.Background(), &sqsMsg)
 
-            mockClient.AssertExpectations(t)
-            if !tt.expectDeleteCall {
-                mockClient.AssertNotCalled(t, "DeleteMessage")
-            }
-        })
-    }
+			mockClient.AssertExpectations(t)
+			if !tt.expectDeleteCall {
+				mockClient.AssertNotCalled(t, "DeleteMessage")
+			}
+		})
+	}
 
-    t.Run("should not process message with nil body", func(t *testing.T) {
-        mockClient := new(MockSQSClient)
-        router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
-        require.NoError(t, err)
-        c := NewConsumer(mockClient, queueURL, router)
+	t.Run("should not process message with nil body", func(t *testing.T) {
+		mockClient := new(MockSQSClient)
+		router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
+		require.NoError(t, err)
+		c := NewConsumer(mockClient, queueURL, router)
 
-        sqsMsg := types.Message{Body: nil, ReceiptHandle: new(string)}
-        c.processMessage(context.Background(), &sqsMsg)
-        // No client calls should be made
-        mockClient.AssertNotCalled(t, "DeleteMessage")
-    })
+		sqsMsg := types.Message{Body: nil, ReceiptHandle: new(string)}
+		c.processMessage(context.Background(), &sqsMsg)
+		// No client calls should be made
+		mockClient.AssertNotCalled(t, "DeleteMessage")
+	})
 }
 
 func TestConsumer_Start(t *testing.T) {
-    queueURL := "test-queue"
-    mockClient := new(MockSQSClient)
-    router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
-    require.NoError(t, err)
+	queueURL := "test-queue"
+	mockClient := new(MockSQSClient)
+	router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
+	require.NoError(t, err)
 
-    // Setup a simple success handler
-    msgType, msgVersion := "test.event", "1.0"
-    router.Register(msgType, msgVersion, func(ctx context.Context, msg []byte, meta []byte) sqsrouter.HandlerResult {
-        return sqsrouter.HandlerResult{ShouldDelete: true}
-    })
+	// Setup a simple success handler
+	msgType, msgVersion := "test.event", "1.0"
+	router.Register(msgType, msgVersion, func(ctx context.Context, msg []byte, meta []byte) sqsrouter.HandlerResult {
+		return sqsrouter.HandlerResult{ShouldDelete: true}
+	})
 
-    c := NewConsumer(mockClient, queueURL, router)
+	c := NewConsumer(mockClient, queueURL, router)
 
-    t.Run("receives and deletes message successfully", func(t *testing.T) {
-        ctx, cancel := context.WithCancel(context.Background())
+	t.Run("receives and deletes message successfully", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
 
-        msgBody := fmt.Sprintf(`{"schemaVersion":"1.0","messageType":"%s","messageVersion":"%s","message":{},"metadata":{"messageId":"msg-1"}}`, msgType, msgVersion)
-        sqsMsg := createSQSMessage(msgBody, "receipt-1")
-        receiveOutput := &sqs.ReceiveMessageOutput{Messages: []types.Message{sqsMsg}}
+		msgBody := fmt.Sprintf(`{"schemaVersion":"1.0","messageType":"%s","messageVersion":"%s","message":{},"metadata":{"messageId":"msg-1"}}`, msgType, msgVersion)
+		sqsMsg := createSQSMessage(msgBody, "receipt-1")
+		receiveOutput := &sqs.ReceiveMessageOutput{Messages: []types.Message{sqsMsg}}
 
-        // Expect ReceiveMessage, then stop the consumer
-        mockClient.On("ReceiveMessage", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-            cancel() // Stop the consumer after the first poll
-        }).Return(receiveOutput, nil).Once()
+		// Expect ReceiveMessage, then stop the consumer
+		mockClient.On("ReceiveMessage", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			cancel() // Stop the consumer after the first poll
+		}).Return(receiveOutput, nil).Once()
 
-        // Expect DeleteMessage to be called for the received message
-        mockClient.On("DeleteMessage", mock.Anything, mock.Anything).Return(&sqs.DeleteMessageOutput{}, nil).Once()
+		// Expect DeleteMessage to be called for the received message
+		mockClient.On("DeleteMessage", mock.Anything, mock.Anything).Return(&sqs.DeleteMessageOutput{}, nil).Once()
 
-        c.Start(ctx)
+		c.Start(ctx)
 
-        mockClient.AssertExpectations(t)
-    })
+		mockClient.AssertExpectations(t)
+	})
 
-    t.Run("handles receive message error gracefully", func(t *testing.T) {
-        mockClient := new(MockSQSClient) // Reset mock for this test
-        c := NewConsumer(mockClient, queueURL, router)
-        // The consumer sleeps for 2s on error, so context must be longer.
-        ctx, cancel := context.WithTimeout(context.Background(), 2500*time.Millisecond)
-        defer cancel()
+	t.Run("handles receive message error gracefully", func(t *testing.T) {
+		mockClient := new(MockSQSClient) // Reset mock for this test
+		c := NewConsumer(mockClient, queueURL, router)
+		// The consumer sleeps for 2s on error, so context must be longer.
+		ctx, cancel := context.WithTimeout(context.Background(), 2500*time.Millisecond)
+		defer cancel()
 
-        // Expect ReceiveMessage to be called and fail, then consumer will sleep.
-        // After sleep, context will be checked again and it will be expired.
-        mockClient.On("ReceiveMessage", mock.Anything, mock.Anything).Return(nil, errors.New("SQS error")).Run(func(args mock.Arguments) {
-            // Cancel the context after the first error to ensure the loop terminates.
-            go func() {
-                time.Sleep(50 * time.Millisecond)
-                cancel()
-            }()
-        }).Once()
+		// Expect ReceiveMessage to be called and fail, then consumer will sleep.
+		// After sleep, context will be checked again and it will be expired.
+		mockClient.On("ReceiveMessage", mock.Anything, mock.Anything).Return(nil, errors.New("SQS error")).Run(func(args mock.Arguments) {
+			// Cancel the context after the first error to ensure the loop terminates.
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				cancel()
+			}()
+		}).Once()
 
-        c.Start(ctx)
+		c.Start(ctx)
 
-        mockClient.AssertExpectations(t)
-    })
+		mockClient.AssertExpectations(t)
+	})
 }
-

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -1,19 +1,19 @@
 package main
 
 import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "log"
-    "os"
-    "os/signal"
-    "syscall"
-    "time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
-    "github.com/aws/aws-sdk-go-v2/config"
-    "github.com/aws/aws-sdk-go-v2/service/sqs"
-    "github.com/hatsunemiku3939/sqsrouter"
-    "github.com/hatsunemiku3939/sqsrouter/consumer"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/hatsunemiku3939/sqsrouter"
+	"github.com/hatsunemiku3939/sqsrouter/consumer"
 )
 
 // --- Schemas ---
@@ -110,8 +110,8 @@ func main() {
 	}
 
 	// --- 4. Setup and Start the Consumer ---
-    c := consumer.NewConsumer(sqsClient, queueURL, router)
-    c.Start(appCtx)
+	c := consumer.NewConsumer(sqsClient, queueURL, router)
+	c.Start(appCtx)
 
 	log.Println("Application has shut down.")
 }

--- a/options.go
+++ b/options.go
@@ -2,6 +2,7 @@ package sqsrouter
 
 import (
 	failure "github.com/hatsunemiku3939/sqsrouter/policy/failure"
+	stypes "github.com/hatsunemiku3939/sqsrouter/types"
 )
 
 // RouterOption configures a Router at construction time.
@@ -13,6 +14,6 @@ func WithFailurePolicy(p failure.Policy) RouterOption {
 }
 
 // WithRoutingPolicy sets a custom routing policy for the Router.
-func WithRoutingPolicy(p RoutingPolicy) RouterOption {
+func WithRoutingPolicy(p stypes.RoutingPolicy) RouterOption {
 	return func(r *Router) { r.routingPolicy = p }
 }

--- a/policy/failure/immediate_test.go
+++ b/policy/failure/immediate_test.go
@@ -1,48 +1,48 @@
 package failure
 
 import (
-    "context"
-    "errors"
-    "testing"
+	"context"
+	"errors"
+	"testing"
 )
 
 func TestImmediateDeletePolicyDecide(t *testing.T) {
-    p := ImmediateDeletePolicy{}
-    ctx := context.Background()
+	p := ImmediateDeletePolicy{}
+	ctx := context.Background()
 
-    base := Result{ShouldDelete: false, Error: nil}
+	base := Result{ShouldDelete: false, Error: nil}
 
-    cases := []struct {
-        name       string
-        kind       Kind
-        innerErr   error
-        current    Result
-        wantDelete bool
-        wantHasErr bool
-    }{
-        {"FailNone_passthrough", FailNone, nil, base, false, false},
-        {"FailEnvelopeSchema_delete", FailEnvelopeSchema, errors.New("schema"), base, true, true},
-        {"FailEnvelopeParse_delete", FailEnvelopeParse, errors.New("parse"), base, true, true},
-        {"FailPayloadSchema_delete", FailPayloadSchema, errors.New("payload"), base, true, true},
-        {"FailNoHandler_delete", FailNoHandler, errors.New("nohandler"), base, true, true},
-        {"FailHandlerError_respect_handler", FailHandlerError, errors.New("handler"), base, false, true},
-        {"FailHandlerPanic_delete", FailHandlerPanic, errors.New("panic"), base, true, true},
-        {"FailMiddlewareError_retry_attach_err", FailMiddlewareError, errors.New("mw"), base, false, true},
-        {"FailMiddlewareError_retry_preserve_existing_err", FailMiddlewareError, errors.New("ignored"), Result{ShouldDelete: false, Error: errors.New("already")}, false, true},
-    }
+	cases := []struct {
+		name       string
+		kind       Kind
+		innerErr   error
+		current    Result
+		wantDelete bool
+		wantHasErr bool
+	}{
+		{"FailNone_passthrough", FailNone, nil, base, false, false},
+		{"FailEnvelopeSchema_delete", FailEnvelopeSchema, errors.New("schema"), base, true, true},
+		{"FailEnvelopeParse_delete", FailEnvelopeParse, errors.New("parse"), base, true, true},
+		{"FailPayloadSchema_delete", FailPayloadSchema, errors.New("payload"), base, true, true},
+		{"FailNoHandler_delete", FailNoHandler, errors.New("nohandler"), base, true, true},
+		{"FailHandlerError_respect_handler", FailHandlerError, errors.New("handler"), base, false, true},
+		{"FailHandlerPanic_delete", FailHandlerPanic, errors.New("panic"), base, true, true},
+		{"FailMiddlewareError_retry_attach_err", FailMiddlewareError, errors.New("mw"), base, false, true},
+		{"FailMiddlewareError_retry_preserve_existing_err", FailMiddlewareError, errors.New("ignored"), Result{ShouldDelete: false, Error: errors.New("already")}, false, true},
+	}
 
-    for _, tc := range cases {
-        t.Run(tc.name, func(t *testing.T) {
-            got := p.Decide(ctx, tc.kind, tc.innerErr, tc.current)
-            if got.ShouldDelete != tc.wantDelete {
-                t.Fatalf("ShouldDelete = %v, want %v", got.ShouldDelete, tc.wantDelete)
-            }
-            if tc.wantHasErr && got.Error == nil {
-                t.Fatalf("expected error to be set, got nil")
-            }
-            if !tc.wantHasErr && got.Error != nil {
-                t.Fatalf("expected no error, got %v", got.Error)
-            }
-        })
-    }
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := p.Decide(ctx, tc.kind, tc.innerErr, tc.current)
+			if got.ShouldDelete != tc.wantDelete {
+				t.Fatalf("ShouldDelete = %v, want %v", got.ShouldDelete, tc.wantDelete)
+			}
+			if tc.wantHasErr && got.Error == nil {
+				t.Fatalf("expected error to be set, got nil")
+			}
+			if !tc.wantHasErr && got.Error != nil {
+				t.Fatalf("expected no error, got %v", got.Error)
+			}
+		})
+	}
 }

--- a/policy/failure/redrive_test.go
+++ b/policy/failure/redrive_test.go
@@ -1,73 +1,73 @@
 package failure
 
 import (
-    "context"
-    "errors"
-    "testing"
+	"context"
+	"errors"
+	"testing"
 )
 
 func TestSQSRedrivePolicyAllFailuresShouldNotDelete(t *testing.T) {
-    p := SQSRedrivePolicy{}
-    ctx := context.Background()
+	p := SQSRedrivePolicy{}
+	ctx := context.Background()
 
-    kinds := []Kind{
-        FailEnvelopeSchema,
-        FailEnvelopeParse,
-        FailPayloadSchema,
-        FailNoHandler,
-        FailHandlerError,
-        FailHandlerPanic,
-        FailMiddlewareError,
-    }
+	kinds := []Kind{
+		FailEnvelopeSchema,
+		FailEnvelopeParse,
+		FailPayloadSchema,
+		FailNoHandler,
+		FailHandlerError,
+		FailHandlerPanic,
+		FailMiddlewareError,
+	}
 
-    for _, k := range kinds {
-        inner := errors.New("inner")
-        curr := Result{ShouldDelete: true, Error: nil}
-        got := p.Decide(ctx, k, inner, curr)
-        if got.ShouldDelete {
-            t.Fatalf("kind %v: expected ShouldDelete=false, got true", k)
-        }
-        if got.Error == nil {
-            t.Fatalf("kind %v: expected Error to be set, got nil", k)
-        }
-    }
+	for _, k := range kinds {
+		inner := errors.New("inner")
+		curr := Result{ShouldDelete: true, Error: nil}
+		got := p.Decide(ctx, k, inner, curr)
+		if got.ShouldDelete {
+			t.Fatalf("kind %v: expected ShouldDelete=false, got true", k)
+		}
+		if got.Error == nil {
+			t.Fatalf("kind %v: expected Error to be set, got nil", k)
+		}
+	}
 }
 
 func TestSQSRedrivePolicyFailNoneUnchanged(t *testing.T) {
-    p := SQSRedrivePolicy{}
-    ctx := context.Background()
+	p := SQSRedrivePolicy{}
+	ctx := context.Background()
 
-    orig := Result{ShouldDelete: true, Error: nil}
-    got := p.Decide(ctx, FailNone, nil, orig)
-    if got.ShouldDelete != orig.ShouldDelete {
-        t.Fatalf("expected ShouldDelete unchanged, got %v", got.ShouldDelete)
-    }
-    if got.Error != orig.Error {
-        t.Fatalf("expected Error unchanged")
-    }
+	orig := Result{ShouldDelete: true, Error: nil}
+	got := p.Decide(ctx, FailNone, nil, orig)
+	if got.ShouldDelete != orig.ShouldDelete {
+		t.Fatalf("expected ShouldDelete unchanged, got %v", got.ShouldDelete)
+	}
+	if got.Error != orig.Error {
+		t.Fatalf("expected Error unchanged")
+	}
 }
 
 func TestSQSRedrivePolicyErrorAttachmentAndPreservation(t *testing.T) {
-    p := SQSRedrivePolicy{}
-    ctx := context.Background()
+	p := SQSRedrivePolicy{}
+	ctx := context.Background()
 
-    inner := errors.New("inner")
-    rr := Result{ShouldDelete: true, Error: nil}
-    got := p.Decide(ctx, FailNoHandler, inner, rr)
-    if got.Error == nil {
-        t.Fatalf("expected inner error attached")
-    }
-    if got.ShouldDelete {
-        t.Fatalf("expected ShouldDelete=false")
-    }
+	inner := errors.New("inner")
+	rr := Result{ShouldDelete: true, Error: nil}
+	got := p.Decide(ctx, FailNoHandler, inner, rr)
+	if got.Error == nil {
+		t.Fatalf("expected inner error attached")
+	}
+	if got.ShouldDelete {
+		t.Fatalf("expected ShouldDelete=false")
+	}
 
-    existing := errors.New("existing")
-    rr2 := Result{ShouldDelete: true, Error: existing}
-    got2 := p.Decide(ctx, FailPayloadSchema, errors.New("ignored"), rr2)
-    if got2.Error != existing {
-        t.Fatalf("expected existing error preserved, got %v", got2.Error)
-    }
-    if got2.ShouldDelete {
-        t.Fatalf("expected ShouldDelete=false")
-    }
+	existing := errors.New("existing")
+	rr2 := Result{ShouldDelete: true, Error: existing}
+	got2 := p.Decide(ctx, FailPayloadSchema, errors.New("ignored"), rr2)
+	if got2.Error != existing {
+		t.Fatalf("expected existing error preserved, got %v", got2.Error)
+	}
+	if got2.ShouldDelete {
+		t.Fatalf("expected ShouldDelete=false")
+	}
 }

--- a/policy/routing/exact_match.go
+++ b/policy/routing/exact_match.go
@@ -3,15 +3,15 @@ package routing
 import (
 	"context"
 
-	"github.com/hatsunemiku3939/sqsrouter"
+	stypes "github.com/hatsunemiku3939/sqsrouter/types"
 )
 
 // ExactMatchPolicy selects handler strictly matching messageType:messageVersion.
 type ExactMatchPolicy struct{}
 
 // Decide returns the exact key if present; otherwise empty.
-func (ExactMatchPolicy) Decide(_ context.Context, envelope *sqsrouter.MessageEnvelope, available []sqsrouter.HandlerKey) sqsrouter.HandlerKey { //nolint:revive
-	want := sqsrouter.HandlerKey(envelope.MessageType + ":" + envelope.MessageVersion)
+func (ExactMatchPolicy) Decide(_ context.Context, envelope *stypes.MessageEnvelope, available []stypes.HandlerKey) stypes.HandlerKey { //nolint:revive
+	want := stypes.HandlerKey(envelope.MessageType + ":" + envelope.MessageVersion)
 	for _, k := range available {
 		if k == want {
 			return k

--- a/policy/routing/exact_match_test.go
+++ b/policy/routing/exact_match_test.go
@@ -1,45 +1,45 @@
 package routing
 
 import (
-    "context"
-    "testing"
+	"context"
+	"testing"
 
-    "github.com/hatsunemiku3939/sqsrouter"
+	stypes "github.com/hatsunemiku3939/sqsrouter/types"
 )
 
 func TestExactMatchPolicy_Table(t *testing.T) {
-    t.Parallel()
-    p := ExactMatchPolicy{}
-    ctx := context.Background()
+	t.Parallel()
+	p := ExactMatchPolicy{}
+	ctx := context.Background()
 
-    cases := []struct {
-        name string
-        env  sqsrouter.MessageEnvelope
-        keys []sqsrouter.HandlerKey
-        want sqsrouter.HandlerKey
-    }{
-        {
-            name: "selects exact match",
-            env:  sqsrouter.MessageEnvelope{MessageType: "A", MessageVersion: "v1"},
-            keys: []sqsrouter.HandlerKey{"A:v0", "A:v1", "B:v1"},
-            want: sqsrouter.HandlerKey("A:v1"),
-        },
-        {
-            name: "returns empty when missing",
-            env:  sqsrouter.MessageEnvelope{MessageType: "A", MessageVersion: "v9"},
-            keys: []sqsrouter.HandlerKey{"A:v0", "B:v1"},
-            want: sqsrouter.HandlerKey(""),
-        },
-    }
+	cases := []struct {
+		name string
+		env  stypes.MessageEnvelope
+		keys []stypes.HandlerKey
+		want stypes.HandlerKey
+	}{
+		{
+			name: "selects exact match",
+			env:  stypes.MessageEnvelope{MessageType: "A", MessageVersion: "v1"},
+			keys: []stypes.HandlerKey{"A:v0", "A:v1", "B:v1"},
+			want: stypes.HandlerKey("A:v1"),
+		},
+		{
+			name: "returns empty when missing",
+			env:  stypes.MessageEnvelope{MessageType: "A", MessageVersion: "v9"},
+			keys: []stypes.HandlerKey{"A:v0", "B:v1"},
+			want: stypes.HandlerKey(""),
+		},
+	}
 
-    for _, tc := range cases {
-        tc := tc
-        t.Run(tc.name, func(t *testing.T) {
-            t.Parallel()
-            got := p.Decide(ctx, &tc.env, tc.keys)
-            if got != tc.want {
-                t.Fatalf("want %q, got %q", tc.want, got)
-            }
-        })
-    }
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := p.Decide(ctx, &tc.env, tc.keys)
+			if got != tc.want {
+				t.Fatalf("want %q, got %q", tc.want, got)
+			}
+		})
+	}
 }

--- a/router_option_test.go
+++ b/router_option_test.go
@@ -1,52 +1,52 @@
 package sqsrouter
 
 import (
-    "context"
-    "errors"
-    "testing"
+	"context"
+	"errors"
+	"testing"
 
-    failure "github.com/hatsunemiku3939/sqsrouter/policy/failure"
+	failure "github.com/hatsunemiku3939/sqsrouter/policy/failure"
 )
 
 type testPolicy struct {
-    lastKind failure.Kind
-    lastErr  error
+	lastKind failure.Kind
+	lastErr  error
 }
 
 func (tp *testPolicy) Decide(ctx context.Context, kind failure.Kind, inner error, current failure.Result) failure.Result { //nolint:revive
-    tp.lastKind = kind
-    tp.lastErr = inner
-    return current
+	tp.lastKind = kind
+	tp.lastErr = inner
+	return current
 }
 
 func TestWithPolicy_SetsRouterPolicy(t *testing.T) {
-    r, err := NewRouter(EnvelopeSchema)
-    if err != nil {
-        t.Fatalf("NewRouter err: %v", err)
-    }
-    if _, ok := r.failurePolicy.(failure.ImmediateDeletePolicy); !ok {
-        t.Fatalf("expected default failure policy ImmediateDeletePolicy")
-    }
+	r, err := NewRouter(EnvelopeSchema)
+	if err != nil {
+		t.Fatalf("NewRouter err: %v", err)
+	}
+	if _, ok := r.failurePolicy.(failure.ImmediateDeletePolicy); !ok {
+		t.Fatalf("expected default failure policy ImmediateDeletePolicy")
+	}
 
-    custom := &testPolicy{}
-    r2, err := NewRouter(EnvelopeSchema, WithFailurePolicy(custom))
-    if err != nil {
-        t.Fatalf("NewRouter err: %v", err)
-    }
-    if r2.failurePolicy != custom {
-        t.Fatalf("WithFailurePolicy did not set custom policy")
-    }
+	custom := &testPolicy{}
+	r2, err := NewRouter(EnvelopeSchema, WithFailurePolicy(custom))
+	if err != nil {
+		t.Fatalf("NewRouter err: %v", err)
+	}
+	if r2.failurePolicy != custom {
+		t.Fatalf("WithFailurePolicy did not set custom policy")
+	}
 
-    rr := RoutedResult{HandlerResult: HandlerResult{}}
-    inner := errors.New("x")
-    // simulate middleware failure path to invoke policy
-    _ = r2.Route(context.Background(), []byte(`{}`)) // not strictly needed but ensure router constructed
-    // Directly call Decide through interface to capture parameters
-    _ = r2.failurePolicy.Decide(context.Background(), failure.FailMiddlewareError, inner, failure.Result{ShouldDelete: rr.HandlerResult.ShouldDelete, Error: rr.HandlerResult.Error})
-    if custom.lastKind != failure.FailMiddlewareError {
-        t.Fatalf("expected custom policy to be invoked with kind=%v, got %v", failure.FailMiddlewareError, custom.lastKind)
-    }
-    if custom.lastErr != inner {
-        t.Fatalf("expected custom policy to receive inner error")
-    }
+	rr := RoutedResult{HandlerResult: HandlerResult{}}
+	inner := errors.New("x")
+	// simulate middleware failure path to invoke policy
+	_ = r2.Route(context.Background(), []byte(`{}`)) // not strictly needed but ensure router constructed
+	// Directly call Decide through interface to capture parameters
+	_ = r2.failurePolicy.Decide(context.Background(), failure.FailMiddlewareError, inner, failure.Result{ShouldDelete: rr.HandlerResult.ShouldDelete, Error: rr.HandlerResult.Error})
+	if custom.lastKind != failure.FailMiddlewareError {
+		t.Fatalf("expected custom policy to be invoked with kind=%v, got %v", failure.FailMiddlewareError, custom.lastKind)
+	}
+	if custom.lastErr != inner {
+		t.Fatalf("expected custom policy to receive inner error")
+	}
 }

--- a/router_routing_policy_test.go
+++ b/router_routing_policy_test.go
@@ -1,47 +1,47 @@
 package sqsrouter
 
 import (
-    "context"
-    "testing"
+	"context"
+	stypes "github.com/hatsunemiku3939/sqsrouter/types"
+	"testing"
 )
 
 // testRoutingPolicy routes any version to v1 if available.
 type testRoutingPolicy struct{}
 
-func (testRoutingPolicy) Decide(_ context.Context, env *MessageEnvelope, available []HandlerKey) HandlerKey { //nolint:revive
-    // prefer exact match
-    exact := HandlerKey(env.MessageType + ":" + env.MessageVersion)
-    for _, k := range available {
-        if k == exact {
-            return k
-        }
-    }
-    // fallback to v1
-    fallback := HandlerKey(env.MessageType + ":v1")
-    for _, k := range available {
-        if k == fallback {
-            return k
-        }
-    }
-    return ""
+func (testRoutingPolicy) Decide(_ context.Context, env *stypes.MessageEnvelope, available []stypes.HandlerKey) stypes.HandlerKey { //nolint:revive
+	// prefer exact match
+	exact := stypes.HandlerKey(env.MessageType + ":" + env.MessageVersion)
+	for _, k := range available {
+		if k == exact {
+			return k
+		}
+	}
+	// fallback to v1
+	fallback := stypes.HandlerKey(env.MessageType + ":v1")
+	for _, k := range available {
+		if k == fallback {
+			return k
+		}
+	}
+	return ""
 }
 
 func TestRoutingPolicy_AllowsFallbackToV1(t *testing.T) {
-    r, err := NewRouter(EnvelopeSchema, WithRoutingPolicy(testRoutingPolicy{}))
-    if err != nil {
-        t.Fatalf("new router: %v", err)
-    }
-    called := false
-    r.Register("T", "v1", func(ctx context.Context, msgJSON []byte, metaJSON []byte) HandlerResult {
-        called = true
-        return HandlerResult{ShouldDelete: true, Error: nil}
-    })
+	r, err := NewRouter(EnvelopeSchema, WithRoutingPolicy(testRoutingPolicy{}))
+	if err != nil {
+		t.Fatalf("new router: %v", err)
+	}
+	called := false
+	r.Register("T", "v1", func(ctx context.Context, msgJSON []byte, metaJSON []byte) HandlerResult {
+		called = true
+		return HandlerResult{ShouldDelete: true, Error: nil}
+	})
 
-    // Send v2 but only v1 is registered; policy should choose v1
-    raw := []byte(`{"schemaVersion":"1.0","messageType":"T","messageVersion":"v2","message":{},"metadata":{}}`)
-    rr := r.Route(context.Background(), raw)
-    if !called || rr.HandlerResult.Error != nil || !rr.HandlerResult.ShouldDelete {
-        t.Fatalf("routing policy fallback failed: %+v", rr)
-    }
+	// Send v2 but only v1 is registered; policy should choose v1
+	raw := []byte(`{"schemaVersion":"1.0","messageType":"T","messageVersion":"v2","message":{},"metadata":{}}`)
+	rr := r.Route(context.Background(), raw)
+	if !called || rr.HandlerResult.Error != nil || !rr.HandlerResult.ShouldDelete {
+		t.Fatalf("routing policy fallback failed: %+v", rr)
+	}
 }
-

--- a/router_test.go
+++ b/router_test.go
@@ -1,15 +1,15 @@
 package sqsrouter
 
 import (
-    "context"
-    "errors"
-    "fmt"
-    "sync"
-    "testing"
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
 
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
-    failure "github.com/hatsunemiku3939/sqsrouter/policy/failure"
+	failure "github.com/hatsunemiku3939/sqsrouter/policy/failure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -150,25 +150,25 @@ func TestRouter_Route(t *testing.T) {
 		assert.True(t, result.HandlerResult.ShouldDelete)
 	})
 
-    t.Run("policy can override handler error decision", func(t *testing.T) {
-        // Custom failure policy that forces retry on handler errors regardless of handler's ShouldDelete
-        tp := failure.Policy(failure.ImmediateDeletePolicy{})
-        // Wrap ImmediateDeletePolicy with a decorator behavior for this test
-        tp = failure.Policy(policyFunc(func(ctx context.Context, kind failure.Kind, inner error, current failure.Result) failure.Result {
-            if kind == failure.FailHandlerError {
-                current.ShouldDelete = false
-                if inner != nil && current.Error == nil {
-                    current.Error = inner
-                }
-            }
-            return current
-        }))
-        r, err := NewRouter(testEnvelopeSchema, WithFailurePolicy(tp))
-        require.NoError(t, err)
-        // Handler asks to delete even on error
-        r.Register(testMessageType, testMessageVersion, func(_ context.Context, _, _ []byte) HandlerResult {
-            return HandlerResult{ShouldDelete: true, Error: errors.New("boom")}
-        })
+	t.Run("policy can override handler error decision", func(t *testing.T) {
+		// Custom failure policy that forces retry on handler errors regardless of handler's ShouldDelete
+		tp := failure.Policy(failure.ImmediateDeletePolicy{})
+		// Wrap ImmediateDeletePolicy with a decorator behavior for this test
+		tp = failure.Policy(policyFunc(func(ctx context.Context, kind failure.Kind, inner error, current failure.Result) failure.Result {
+			if kind == failure.FailHandlerError {
+				current.ShouldDelete = false
+				if inner != nil && current.Error == nil {
+					current.Error = inner
+				}
+			}
+			return current
+		}))
+		r, err := NewRouter(testEnvelopeSchema, WithFailurePolicy(tp))
+		require.NoError(t, err)
+		// Handler asks to delete even on error
+		r.Register(testMessageType, testMessageVersion, func(_ context.Context, _, _ []byte) HandlerResult {
+			return HandlerResult{ShouldDelete: true, Error: errors.New("boom")}
+		})
 
 		payload := `{"userId": "123", "username": "test"}`
 		msg := createTestMessage(t, testMessageType, testMessageVersion, payload)
@@ -276,7 +276,7 @@ func TestRouter_Route(t *testing.T) {
 type policyFunc func(ctx context.Context, kind failure.Kind, inner error, current failure.Result) failure.Result
 
 func (f policyFunc) Decide(ctx context.Context, kind failure.Kind, inner error, current failure.Result) failure.Result {
-    return f(ctx, kind, inner, current)
+	return f(ctx, kind, inner, current)
 }
 
 func TestRouter_Concurrency(t *testing.T) {

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -1,20 +1,20 @@
 package main
 
 import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "log"
-    "os"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
 	"os/signal"
 	"syscall"
 
-    "github.com/aws/aws-sdk-go-v2/aws"
-    "github.com/aws/aws-sdk-go-v2/config"
-    "github.com/aws/aws-sdk-go-v2/service/sqs"
-    "github.com/hatsunemiku3939/sqsrouter"
-    "github.com/hatsunemiku3939/sqsrouter/consumer"
-    failure "github.com/hatsunemiku3939/sqsrouter/policy/failure"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/hatsunemiku3939/sqsrouter"
+	"github.com/hatsunemiku3939/sqsrouter/consumer"
+	failure "github.com/hatsunemiku3939/sqsrouter/policy/failure"
 )
 
 const (
@@ -107,13 +107,13 @@ type forceRetryOnHandlerErr struct{}
 
 // Decide implements the FailurePolicy interface for the custom behavior.
 func (forceRetryOnHandlerErr) Decide(_ context.Context, kind failure.Kind, inner error, current failure.Result) failure.Result {
-    if kind == failure.FailHandlerError {
-        current.ShouldDelete = false
-        if inner != nil && current.Error == nil {
-            current.Error = inner
-        }
-    }
-    return current
+	if kind == failure.FailHandlerError {
+		current.ShouldDelete = false
+		if inner != nil && current.Error == nil {
+			current.Error = inner
+		}
+	}
+	return current
 }
 
 func main() {
@@ -153,11 +153,11 @@ func main() {
 	sqsClient := sqs.NewFromConfig(cfg)
 
 	// Optionally install a custom policy that forces retry for handler errors.
-    var opts []sqsrouter.RouterOption
-    if os.Getenv("E2E_POLICY_FORCE_RETRY_ON_HANDLER_ERR") == "1" {
-        // Custom policy: turn any handler error into a retry (ShouldDelete=false)
-        opts = append(opts, sqsrouter.WithFailurePolicy(forceRetryOnHandlerErr{}))
-    }
+	var opts []sqsrouter.RouterOption
+	if os.Getenv("E2E_POLICY_FORCE_RETRY_ON_HANDLER_ERR") == "1" {
+		// Custom policy: turn any handler error into a retry (ShouldDelete=false)
+		opts = append(opts, sqsrouter.WithFailurePolicy(forceRetryOnHandlerErr{}))
+	}
 
 	router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema, opts...)
 	if err != nil {
@@ -180,8 +180,8 @@ func main() {
 
 	router.Register(MsgTypeE2ETest, MsgVersion1_0, E2ETestHandler)
 
-    c := consumer.NewConsumer(sqsClient, queueURL, router)
-    c.Start(appCtx)
+	c := consumer.NewConsumer(sqsClient, queueURL, router)
+	c.Start(appCtx)
 
 	log.Println("Application has shut down.")
 }

--- a/types/types.go
+++ b/types/types.go
@@ -1,0 +1,33 @@
+package types
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// MessageEnvelope is a struct to unmarshal the outer layer of an SQS message.
+// It contains the routing information and the actual message payload.
+type MessageEnvelope struct {
+	SchemaVersion  string          `json:"schemaVersion"`
+	MessageType    string          `json:"messageType"`
+	MessageVersion string          `json:"messageVersion"`
+	Message        json.RawMessage `json:"message"`
+	Metadata       MessageMetadata `json:"metadata"`
+}
+
+// MessageMetadata holds common metadata found in every message.
+type MessageMetadata struct {
+	Timestamp string `json:"timestamp"`
+	Source    string `json:"source"`
+	MessageID string `json:"messageId"`
+}
+
+// HandlerKey is the unique identifier for a registered handler (e.g., "messageType:messageVersion").
+type HandlerKey string
+
+// RoutingPolicy decides which handler should process an incoming message.
+// Implementations may perform exact match, version fallback, A/B testing, etc.
+// Returning an empty HandlerKey means no handler selected.
+type RoutingPolicy interface {
+	Decide(ctx context.Context, envelope *MessageEnvelope, availableHandlers []HandlerKey) HandlerKey
+}


### PR DESCRIPTION
## Summary

Extract commonly used types into a new `types` package to break import cycles and allow `router.go` to use `routing.ExactMatchPolicy{}` as the default. Update references across the repo, refresh docs, and keep behavior equivalent.

## Related issue(s)
- N/A (structural refactor to enable cleaner dependencies)

## Implementation details
- Move `MessageEnvelope`, `MessageMetadata`, `HandlerKey`, `RoutingPolicy` to `types/types.go`.
- Replace internal default policy with `policy/routing.ExactMatchPolicy{}` in `router.go`.
- Update `sqsrouter` to reference `types` for routing policy and envelope/meta types.
- Update `policy/routing` to reference `types` instead of `sqsrouter`.
- Adjust `WithRoutingPolicy` signature to accept `types.RoutingPolicy`.
- Update tests and documentation (`README.md`, `AGENTS.md`).
- Run `gofmt`, `make lint`, and `make test` locally (all green).

## Test coverage
- Existing unit tests updated to import `types`; all tests pass.
- No behavior changes in routing/consumer paths; only dependency direction changes.

## Breaking changes
- `RoutingPolicy`, `MessageEnvelope`, and `HandlerKey` moved to `github.com/hatsunemiku3939/sqsrouter/types`.
  - Update imports: use `types.RoutingPolicy`, `types.MessageEnvelope`, `types.HandlerKey`.

## Notes
- This decouples `policy/routing` from `sqsrouter`, eliminating cycles and making the default exact-match policy selectable without indirection.

Created by Codex
