### PR TITLE
feat(consumer): add Consumer interface and FIFO consumer; refactor Standard consumer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,10 +44,11 @@ A concise, automation-friendly guide for AI agents and tooling to understand, na
   - func (r *Router) Use(mw ...Middleware)
   - func (r *Router) Route(ctx context.Context, rawMessage []byte) RoutedResult
   - EnvelopeSchema (JSON Schema for envelope)
-- consumer/consumer.go
-  - type SQSClient interface { ReceiveMessage(...); DeleteMessage(...) }
-  - func NewConsumer(client SQSClient, queueURL string, router *sqsrouter.Router) *Consumer
-  - func (c *Consumer) Start(ctx context.Context)
+- consumer/
+  - interface.go: `type Consumer interface { Start(ctx context.Context) }`
+  - standard_consumer.go: `type StandardConsumer` + `func NewStandardConsumer(...) Consumer`
+  - fifo_consumer.go: `type FIFOConsumer` + `func NewFIFOConsumer(...) Consumer`
+  - SQS client contract: `type SQSClient interface { ReceiveMessage(...); DeleteMessage(...) }`
 - Failure policy
   - spec.FailureKind / spec.FailureResult / spec.FailurePolicy
   - policy/failure: ImmediateDeletePolicy, SQSRedrivePolicy
@@ -66,10 +67,11 @@ A concise, automation-friendly guide for AI agents and tooling to understand, na
 
 ## Consumer Lifecycle
 - Long polls ReceiveMessage(maxMessages=5, waitTimeSeconds=10).
-- Each message processed in its own goroutine with processingTimeout=30s.
+- StandardConsumer: processes each message in its own goroutine with processingTimeout=30s.
+- FIFOConsumer: processes messages sequentially and stops the batch on first failure (ShouldDelete=false).
 - On RoutedResult.ShouldDelete=true, DeleteMessage with deleteTimeout=5s.
 - On false, message is left for retry (visibility timeout expiry).
-- Graceful shutdown via context cancellation; waits for in-flight messages.
+- Graceful shutdown via context cancellation; Standard waits for in-flight goroutines; FIFO returns after loop.
 
 ## Examples
 - example/basic/main.go: Registers handler and payload schema for "updateUserProfile" v1.0, starts Consumer.

--- a/README.md
+++ b/README.md
@@ -97,10 +97,17 @@ func main() {
   router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
   if err != nil { panic(err) }
 
-  c := consumer.NewConsumer(client, "https://sqs.{region}.amazonaws.com/{account}/{queue}", router)
+  c := consumer.NewStandardConsumer(client, "https://sqs.{region}.amazonaws.com/{account}/{queue}", router)
   ctx := context.Background()
   c.Start(ctx) // blocks until ctx is canceled
 }
+```
+
+### FIFO queues (strict ordering)
+```go
+// For FIFO queues, use the sequential consumer to maintain order.
+c := consumer.NewFIFOConsumer(client, "https://sqs.{region}.amazonaws.com/{account}/{queue}.fifo", router)
+c.Start(context.Background())
 ```
 
 ## Usage
@@ -196,7 +203,10 @@ router, _ := sqsrouter.NewRouter(
 ## Project Structure
 ```
 sqsrouter/
-├── consumer/                    # SQS polling and lifecycle (receive/delete, timeouts, concurrency)
+├── consumer/                    # SQS polling and lifecycle (receive/delete, timeouts)
+│   ├── interface.go             # Consumer interface
+│   ├── standard_consumer.go     # Concurrent consumer for standard queues
+│   └── fifo_consumer.go         # Sequential consumer for FIFO queues
 ├── internal/jsonschema/         # JSON schema validation utilities
 ├── policy/
 │   ├── failure/                 # Built-in failure policies (ImmediateDeletePolicy, SQSRedrivePolicy)

--- a/consumer/fifo_consumer.go
+++ b/consumer/fifo_consumer.go
@@ -1,0 +1,142 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/hatsunemiku3939/sqsrouter"
+)
+
+// FIFOConsumer processes messages sequentially to guarantee order for FIFO queues.
+type FIFOConsumer struct {
+	client   SQSClient
+	queueURL string
+	router   *sqsrouter.Router
+}
+
+// NewFIFOConsumer creates a new consumer specifically for FIFO SQS queues.
+func NewFIFOConsumer(client SQSClient, queueURL string, router *sqsrouter.Router) Consumer {
+	return &FIFOConsumer{client: client, queueURL: queueURL, router: router}
+}
+
+// Start begins the sequential polling and processing loop.
+func (c *FIFOConsumer) Start(ctx context.Context) {
+	log.Printf("🚀 SQS FIFO consumer started. Polling queue: %s. Press Ctrl+C to shut down.", c.queueURL)
+
+	for {
+		// Before polling, check if a shutdown has been initiated.
+		if ctx.Err() != nil {
+			log.Println("INFO: Shutdown initiated, no longer polling for new messages.")
+			break
+		}
+
+		output, err := c.client.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+			QueueUrl:            aws.String(c.queueURL),
+			MaxNumberOfMessages: maxMessages,
+			WaitTimeSeconds:     waitTimeSeconds,
+			MessageSystemAttributeNames: []sqstypes.MessageSystemAttributeName{
+				sqstypes.MessageSystemAttributeNameAll,
+			},
+			MessageAttributeNames: []string{"All"},
+		})
+
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				log.Println("INFO: Context canceled by shutdown signal. Stopping poller.")
+				break // Exit the loop cleanly.
+			}
+			log.Printf("ERROR: Failed to receive messages: %v. Retrying...", err)
+			// Wait before retrying on other errors.
+			// Sequential consumer maintains same backoff as standard consumer.
+			time.Sleep(retrySleep)
+			continue
+		}
+
+		if len(output.Messages) == 0 {
+			continue
+		}
+
+		log.Printf("INFO: Received %d messages.", len(output.Messages))
+
+		// Process messages sequentially
+		stopBatch := false
+		for _, m := range output.Messages {
+			if stopBatch {
+				break
+			}
+			// Per-message timeout
+			msgCtx, cancelMsg := context.WithTimeout(ctx, processingTimeout)
+			// Attach MessageContext built from SQS attributes
+			msgCtx = sqsrouter.WithMessageContext(msgCtx, buildMessageContext(&m))
+			stopBatch = !c.processMessage(msgCtx, &m)
+			cancelMsg()
+		}
+	}
+
+	log.Println("✅ Graceful shutdown complete (FIFO consumer).")
+}
+
+// processMessage handles a single message and returns true if batch can continue, false to stop batch.
+func (c *FIFOConsumer) processMessage(ctx context.Context, msg *sqstypes.Message) bool {
+	defer func() {
+		if rec := recover(); rec != nil {
+			log.Printf("ERROR: Panic recovered while processing a message: %v", rec)
+		}
+	}()
+
+	if msg.Body == nil {
+		log.Println("ERROR: Received message with empty body.")
+		// Treat as failure; do not continue the batch to preserve order.
+		return false
+	}
+
+	routed := c.router.Route(ctx, []byte(*msg.Body))
+
+	if routed.HandlerResult.Error != nil {
+		log.Printf("❌ FAILURE [%s] %s v%s (%s): %v",
+			routed.Timestamp,
+			routed.MessageType,
+			routed.MessageVersion,
+			routed.MessageID,
+			routed.HandlerResult.Error,
+		)
+	} else {
+		log.Printf("✅ SUCCESS [%s] %s v%s (%s)",
+			routed.Timestamp,
+			routed.MessageType,
+			routed.MessageVersion,
+			routed.MessageID,
+		)
+	}
+
+	if routed.HandlerResult.ShouldDelete {
+		deleteCtx, cancelDelete := context.WithTimeout(context.Background(), deleteTimeout)
+		defer cancelDelete()
+
+		//nolint:contextcheck
+		_, err := c.client.DeleteMessage(deleteCtx, &sqs.DeleteMessageInput{
+			QueueUrl:      aws.String(c.queueURL),
+			ReceiptHandle: msg.ReceiptHandle,
+		})
+
+		if err != nil {
+			log.Printf("ERROR: Failed to delete message ID %s: %v", routed.MessageID, err)
+			// Deletion failure can break ordering; stop batch to avoid processing newer messages first.
+			return false
+		}
+
+		log.Printf("🗑️  Deleted message ID %s", routed.MessageID)
+		return true
+	}
+
+	log.Printf("🔁 RETRYING message ID %s later (visibility timeout will expire).", routed.MessageID)
+	// Fail-fast: stop processing remaining messages in the batch.
+	return false
+}
+
+// no extra helpers needed; FIFO uses same timing constants as standard consumer.

--- a/consumer/fifo_consumer.go
+++ b/consumer/fifo_consumer.go
@@ -70,10 +70,10 @@ func (c *FIFOConsumer) Start(ctx context.Context) {
 				break
 			}
 			// Per-message timeout
-			msgCtx, cancelMsg := context.WithTimeout(ctx, processingTimeout)
+			msgCtx, cancelMsg := context.WithTimeout(context.Background(), processingTimeout) //nolint:contextcheck
 			// Attach MessageContext built from SQS attributes
 			msgCtx = sqsrouter.WithMessageContext(msgCtx, buildMessageContext(&m))
-			stopBatch = !c.processMessage(msgCtx, &m)
+			stopBatch = !c.processMessage(msgCtx, &m) //nolint:contextcheck
 			cancelMsg()
 		}
 	}

--- a/consumer/fifo_consumer_test.go
+++ b/consumer/fifo_consumer_test.go
@@ -1,0 +1,112 @@
+package consumer
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	sqsrouter "github.com/hatsunemiku3939/sqsrouter"
+	"github.com/hatsunemiku3939/sqsrouter/spec"
+)
+
+func TestFIFOConsumer_SequentialSuccessDeletesBoth(t *testing.T) {
+	queueURL := "test-queue"
+	mockClient := new(MockSQSClient)
+
+	router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
+	require.NoError(t, err)
+
+	// Two message types to differentiate handlers
+	typeA, ver := "typeA", "1.0"
+	typeB := "typeB"
+	router.Register(typeA, ver, func(ctx context.Context, msg []byte) spec.HandlerResult {
+		return spec.HandlerResult{ShouldDelete: true}
+	})
+	router.Register(typeB, ver, func(ctx context.Context, msg []byte) spec.HandlerResult {
+		return spec.HandlerResult{ShouldDelete: true}
+	})
+
+	c := NewFIFOConsumer(mockClient, queueURL, router)
+
+	// Prepare two messages in one batch
+	bodyA := fmt.Sprintf(`{"schemaVersion":"1.0","messageType":"%s","messageVersion":"%s","message":{},"metadata":{"messageId":"a"}}`, typeA, ver)
+	bodyB := fmt.Sprintf(`{"schemaVersion":"1.0","messageType":"%s","messageVersion":"%s","message":{},"metadata":{"messageId":"b"}}`, typeB, ver)
+	r1 := "receipt-1"
+	r2 := "receipt-2"
+	msgA := sqstypes.Message{Body: &bodyA, ReceiptHandle: &r1}
+	msgB := sqstypes.Message{Body: &bodyB, ReceiptHandle: &r2}
+
+	// Expect one ReceiveMessage returning both messages, then cancel
+	ctx, cancel := context.WithCancel(context.Background())
+	mockClient.
+		On("ReceiveMessage", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) { cancel() }).
+		Return(&sqs.ReceiveMessageOutput{Messages: []sqstypes.Message{msgA, msgB}}, nil).
+		Once()
+
+	// Expect DeleteMessage called for r1 then r2
+	call1 := mockClient.On("DeleteMessage", mock.Anything, mock.MatchedBy(func(in *sqs.DeleteMessageInput) bool {
+		return in != nil && in.ReceiptHandle != nil && *in.ReceiptHandle == r1
+	})).Return(&sqs.DeleteMessageOutput{}, nil).Once()
+	call2 := mockClient.On("DeleteMessage", mock.Anything, mock.MatchedBy(func(in *sqs.DeleteMessageInput) bool {
+		return in != nil && in.ReceiptHandle != nil && *in.ReceiptHandle == r2
+	})).Return(&sqs.DeleteMessageOutput{}, nil).Once()
+	mock.InOrder(call1, call2)
+
+	c.Start(ctx)
+
+	mockClient.AssertExpectations(t)
+}
+
+func TestFIFOConsumer_FailFastStopsBatch(t *testing.T) {
+	queueURL := "test-queue"
+	mockClient := new(MockSQSClient)
+
+	router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
+	require.NoError(t, err)
+
+	typeA, ver := "typeA", "1.0"
+	typeB := "typeB"
+
+	// First handler fails and ShouldDelete=false
+	router.Register(typeA, ver, func(ctx context.Context, msg []byte) spec.HandlerResult {
+		return spec.HandlerResult{ShouldDelete: false, Error: fmt.Errorf("transient")}
+	})
+
+	// Second handler increments a counter if ever called
+	var bCount int32
+	router.Register(typeB, ver, func(ctx context.Context, msg []byte) spec.HandlerResult {
+		atomic.AddInt32(&bCount, 1)
+		return spec.HandlerResult{ShouldDelete: true}
+	})
+
+	c := NewFIFOConsumer(mockClient, queueURL, router)
+
+	bodyA := fmt.Sprintf(`{"schemaVersion":"1.0","messageType":"%s","messageVersion":"%s","message":{},"metadata":{"messageId":"a"}}`, typeA, ver)
+	bodyB := fmt.Sprintf(`{"schemaVersion":"1.0","messageType":"%s","messageVersion":"%s","message":{},"metadata":{"messageId":"b"}}`, typeB, ver)
+	r1 := "receipt-1"
+	r2 := "receipt-2"
+	msgA := sqstypes.Message{Body: &bodyA, ReceiptHandle: &r1}
+	msgB := sqstypes.Message{Body: &bodyB, ReceiptHandle: &r2}
+
+	// One poll then cancel
+	ctx, cancel := context.WithCancel(context.Background())
+	mockClient.
+		On("ReceiveMessage", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) { cancel() }).
+		Return(&sqs.ReceiveMessageOutput{Messages: []sqstypes.Message{msgA, msgB}}, nil).
+		Once()
+
+	// Expect no DeleteMessage calls because first message returns ShouldDelete=false
+	c.Start(ctx)
+
+	mockClient.AssertExpectations(t)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&bCount), "second handler should not run on fail-fast")
+}

--- a/consumer/helpers.go
+++ b/consumer/helpers.go
@@ -1,0 +1,53 @@
+package consumer
+
+import (
+	"strconv"
+	"time"
+
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/hatsunemiku3939/sqsrouter/spec"
+)
+
+// buildMessageContext constructs a spec.MessageContext from an SQS message.
+func buildMessageContext(m *sqstypes.Message) *spec.MessageContext {
+	if m == nil {
+		return &spec.MessageContext{}
+	}
+	mc := &spec.MessageContext{CustomAttributes: map[string]sqstypes.MessageAttributeValue{}}
+	// Copy message attributes directly (safe to range over nil map)
+	for k, v := range m.MessageAttributes {
+		mc.CustomAttributes[k] = v
+	}
+	// Parse system attributes (map lookup on nil map is safe)
+	if v, ok := m.Attributes[string(sqstypes.MessageSystemAttributeNameApproximateReceiveCount)]; ok {
+		if n, err := strconv.Atoi(v); err == nil {
+			mc.ReceiveCount = n
+		}
+	}
+	if v, ok := m.Attributes[string(sqstypes.MessageSystemAttributeNameSentTimestamp)]; ok {
+		if ts, err := parseEpochMillis(v); err == nil {
+			mc.SentTimestamp = ts
+		}
+	}
+	if v, ok := m.Attributes[string(sqstypes.MessageSystemAttributeNameApproximateFirstReceiveTimestamp)]; ok {
+		if ts, err := parseEpochMillis(v); err == nil {
+			mc.FirstReceiveTimestamp = ts
+		}
+	}
+	if v, ok := m.Attributes[string(sqstypes.MessageSystemAttributeNameMessageGroupId)]; ok {
+		mc.MessageGroupID = v
+	}
+	if v, ok := m.Attributes[string(sqstypes.MessageSystemAttributeNameMessageDeduplicationId)]; ok {
+		mc.MessageDeduplicationID = v
+	}
+	return mc
+}
+
+// parseEpochMillis converts a string epoch millis to time.Time.
+func parseEpochMillis(s string) (time.Time, error) {
+	ms, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(0, ms*int64(time.Millisecond)), nil
+}

--- a/consumer/interface.go
+++ b/consumer/interface.go
@@ -1,0 +1,10 @@
+package consumer
+
+import "context"
+
+// Consumer defines the standard interface for an SQS message consumer.
+// It is responsible for starting the message polling and processing loop.
+type Consumer interface {
+	// Start begins the consumer's polling loop. It blocks until the context is canceled.
+	Start(ctx context.Context)
+}

--- a/consumer/standard_consumer.go
+++ b/consumer/standard_consumer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"log"
-	"strconv"
 	"sync"
 	"time"
 
@@ -12,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/hatsunemiku3939/sqsrouter"
-	"github.com/hatsunemiku3939/sqsrouter/spec"
 )
 
 // --- SQS Consumer Configuration ---
@@ -37,20 +35,20 @@ type SQSClient interface {
 	DeleteMessage(ctx context.Context, params *sqs.DeleteMessageInput, optFns ...func(*sqs.Options)) (*sqs.DeleteMessageOutput, error)
 }
 
-// Consumer encapsulates the SQS polling and message processing logic.
-type Consumer struct {
+// StandardConsumer processes messages concurrently for high throughput.
+type StandardConsumer struct {
 	client   SQSClient
 	queueURL string
 	router   *sqsrouter.Router
 }
 
-// NewConsumer creates a new SQS message consumer.
-func NewConsumer(client SQSClient, queueURL string, router *sqsrouter.Router) *Consumer {
-	return &Consumer{client: client, queueURL: queueURL, router: router}
+// NewStandardConsumer creates a new consumer for standard SQS queues.
+func NewStandardConsumer(client SQSClient, queueURL string, router *sqsrouter.Router) Consumer {
+	return &StandardConsumer{client: client, queueURL: queueURL, router: router}
 }
 
 // Start begins the consumer's polling loop. It blocks until the context is canceled.
-func (c *Consumer) Start(ctx context.Context) {
+func (c *StandardConsumer) Start(ctx context.Context) {
 	log.Printf("🚀 SQS consumer started. Polling queue: %s. Press Ctrl+C to shut down.", c.queueURL)
 
 	var wg sync.WaitGroup
@@ -109,7 +107,7 @@ func (c *Consumer) Start(ctx context.Context) {
 }
 
 // processMessage routes, handles, and deletes a single SQS message.
-func (c *Consumer) processMessage(ctx context.Context, msg *sqstypes.Message) {
+func (c *StandardConsumer) processMessage(ctx context.Context, msg *sqstypes.Message) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			log.Printf("ERROR: Panic recovered while processing a message: %v", rec)
@@ -158,48 +156,4 @@ func (c *Consumer) processMessage(ctx context.Context, msg *sqstypes.Message) {
 	} else {
 		log.Printf("🔁 RETRYING message ID %s later (visibility timeout will expire).", routed.MessageID)
 	}
-}
-
-// buildMessageContext constructs a spec.MessageContext from an SQS message.
-func buildMessageContext(m *sqstypes.Message) *spec.MessageContext {
-	if m == nil {
-		return &spec.MessageContext{}
-	}
-	mc := &spec.MessageContext{CustomAttributes: map[string]sqstypes.MessageAttributeValue{}}
-	// Copy message attributes directly (safe to range over nil map)
-	for k, v := range m.MessageAttributes {
-		mc.CustomAttributes[k] = v
-	}
-	// Parse system attributes (map lookup on nil map is safe)
-	if v, ok := m.Attributes[string(sqstypes.MessageSystemAttributeNameApproximateReceiveCount)]; ok {
-		if n, err := strconv.Atoi(v); err == nil {
-			mc.ReceiveCount = n
-		}
-	}
-	if v, ok := m.Attributes[string(sqstypes.MessageSystemAttributeNameSentTimestamp)]; ok {
-		if ts, err := parseEpochMillis(v); err == nil {
-			mc.SentTimestamp = ts
-		}
-	}
-	if v, ok := m.Attributes[string(sqstypes.MessageSystemAttributeNameApproximateFirstReceiveTimestamp)]; ok {
-		if ts, err := parseEpochMillis(v); err == nil {
-			mc.FirstReceiveTimestamp = ts
-		}
-	}
-	if v, ok := m.Attributes[string(sqstypes.MessageSystemAttributeNameMessageGroupId)]; ok {
-		mc.MessageGroupID = v
-	}
-	if v, ok := m.Attributes[string(sqstypes.MessageSystemAttributeNameMessageDeduplicationId)]; ok {
-		mc.MessageDeduplicationID = v
-	}
-	return mc
-}
-
-// parseEpochMillis converts a string epoch millis to time.Time.
-func parseEpochMillis(s string) (time.Time, error) {
-	ms, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return time.Unix(0, ms*int64(time.Millisecond)), nil
 }

--- a/consumer/standard_consumer_test.go
+++ b/consumer/standard_consumer_test.go
@@ -41,19 +41,20 @@ func createSQSMessage(body, receiptHandle string) types.Message {
 	return types.Message{Body: &body, ReceiptHandle: &receiptHandle}
 }
 
-func TestNewConsumer(t *testing.T) {
+func TestNewStandardConsumer(t *testing.T) {
 	mockClient := new(MockSQSClient)
 	router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
 	require.NoError(t, err)
-	c := NewConsumer(mockClient, "test-queue-url", router)
+	c := NewStandardConsumer(mockClient, "test-queue-url", router)
 
 	assert.NotNil(t, c)
-	assert.Equal(t, "test-queue-url", c.queueURL)
-	assert.Equal(t, mockClient, c.client)
-	assert.Equal(t, router, c.router)
+	sc := c.(*StandardConsumer)
+	assert.Equal(t, "test-queue-url", sc.queueURL)
+	assert.Equal(t, mockClient, sc.client)
+	assert.Equal(t, router, sc.router)
 }
 
-func TestConsumer_processMessage(t *testing.T) {
+func TestStandardConsumer_processMessage(t *testing.T) {
 	queueURL := "test-queue"
 
 	tests := []struct {
@@ -109,7 +110,7 @@ func TestConsumer_processMessage(t *testing.T) {
 			msgType, msgVersion := "test.event", "1.0"
 			router.Register(msgType, msgVersion, tt.handler)
 
-			c := NewConsumer(mockClient, queueURL, router)
+			c := NewStandardConsumer(mockClient, queueURL, router)
 
 			msgBody := fmt.Sprintf(`{
                 "schemaVersion": "1.0", "messageType": "%s", "messageVersion": "%s",
@@ -126,7 +127,7 @@ func TestConsumer_processMessage(t *testing.T) {
 				}
 			}
 
-			c.processMessage(context.Background(), &sqsMsg)
+			c.(*StandardConsumer).processMessage(context.Background(), &sqsMsg)
 
 			mockClient.AssertExpectations(t)
 			if !tt.expectDeleteCall {
@@ -139,16 +140,16 @@ func TestConsumer_processMessage(t *testing.T) {
 		mockClient := new(MockSQSClient)
 		router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
 		require.NoError(t, err)
-		c := NewConsumer(mockClient, queueURL, router)
+		c := NewStandardConsumer(mockClient, queueURL, router)
 
 		sqsMsg := types.Message{Body: nil, ReceiptHandle: new(string)}
-		c.processMessage(context.Background(), &sqsMsg)
+		c.(*StandardConsumer).processMessage(context.Background(), &sqsMsg)
 		// No client calls should be made
 		mockClient.AssertNotCalled(t, "DeleteMessage")
 	})
 }
 
-func TestConsumer_Start(t *testing.T) {
+func TestStandardConsumer_Start(t *testing.T) {
 	queueURL := "test-queue"
 	mockClient := new(MockSQSClient)
 	router, err := sqsrouter.NewRouter(sqsrouter.EnvelopeSchema)
@@ -160,7 +161,7 @@ func TestConsumer_Start(t *testing.T) {
 		return spec.HandlerResult{ShouldDelete: true}
 	})
 
-	c := NewConsumer(mockClient, queueURL, router)
+	c := NewStandardConsumer(mockClient, queueURL, router)
 
 	t.Run("receives and deletes message successfully", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -184,7 +185,7 @@ func TestConsumer_Start(t *testing.T) {
 
 	t.Run("handles receive message error gracefully", func(t *testing.T) {
 		mockClient := new(MockSQSClient) // Reset mock for this test
-		c := NewConsumer(mockClient, queueURL, router)
+		c := NewStandardConsumer(mockClient, queueURL, router)
 		// The consumer sleeps for 2s on error, so context must be longer.
 		ctx, cancel := context.WithTimeout(context.Background(), 2500*time.Millisecond)
 		defer cancel()

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -115,7 +115,8 @@ func main() {
 	}
 
 	// --- 4. Setup and Start the Consumer ---
-	c := consumer.NewConsumer(sqsClient, queueURL, router)
+	// Use StandardConsumer for standard SQS queues (concurrent processing).
+	c := consumer.NewStandardConsumer(sqsClient, queueURL, router)
 	c.Start(appCtx)
 
 	log.Println("Application has shut down.")

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -184,7 +184,7 @@ func main() {
 
 	router.Register(MsgTypeE2ETest, MsgVersion1_0, E2ETestHandler)
 
-	c := consumer.NewConsumer(sqsClient, queueURL, router)
+	c := consumer.NewStandardConsumer(sqsClient, queueURL, router)
 	c.Start(appCtx)
 
 	log.Println("Application has shut down.")


### PR DESCRIPTION
## Summary
Introduce a `Consumer` interface with two implementations:
- `StandardConsumer`: concurrent processing for standard SQS queues.
- `FIFOConsumer`: sequential processing with fail-fast per batch for FIFO queues.

Refactor the existing consumer to `StandardConsumer` and update docs/examples/tests accordingly.

## Related issue(s)
- Closes #53

## Implementation details
- Add `consumer.Consumer` interface (`Start(context.Context)`).
- Rename and refactor existing consumer to `StandardConsumer` with `NewStandardConsumer` constructor.
- Implement `FIFOConsumer` with sequential processing and fail-fast on `ShouldDelete=false` or delete failure.
- Extract shared helpers for message context building.
- Update README, AGENTS.md, example app, and e2e app to use the new constructors.

## Test coverage
- Update unit tests for `StandardConsumer`.
- Add unit tests for `FIFOConsumer`:
  - Processes a batch sequentially and deletes both messages.
  - Stops processing the batch on first failure (no deletes, next handler not invoked).
- Lint passes; unit tests pass locally.

## Breaking changes
- Constructor `NewConsumer` is replaced by `NewStandardConsumer`.
- Users of FIFO queues should construct `NewFIFOConsumer` to ensure strict ordering.

## Notes
- Kept SQS client interface as-is for mocking.
- E2E unchanged in behavior; updated to use `NewStandardConsumer`.

Created by Codex
